### PR TITLE
Validate module fields

### DIFF
--- a/src/components/Admin/EditorToolbar.vue
+++ b/src/components/Admin/EditorToolbar.vue
@@ -8,10 +8,12 @@
   <confirmation-toggle v-if="!hideDelete"
                        @confirmed="$emit('delete')">{{ $t('general.label.delete') }}</confirmation-toggle>
   <b-button v-if="!hideSave"
+            :disabled="disableSave"
             variant="primary"
             @click.prevent="$emit('save')"
             class="float-right">{{ $t('general.label.save') }}</b-button>
   <b-button v-if="!hideSave"
+            :disabled="disableSave"
             variant="primary" @click.prevent="$emit('saveAndClose')"
             class="float-right mr-1">{{ $t('general.label.saveAndClose') }}</b-button>
 </div>
@@ -36,6 +38,11 @@ export default {
     hideSave: {
       type: Boolean,
       required: false,
+    },
+    disableSave: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 }

--- a/src/components/Admin/Module/FieldRowEdit.vue
+++ b/src/components/Admin/Module/FieldRowEdit.vue
@@ -17,8 +17,8 @@
     </td>
     <td>
       <b-input v-model="value.label"
-             type="text"
-             class="form-control"/>
+               type="text"
+               class="form-control"/>
     </td>
     <td>
       <b-select v-model="value.kind" :disabled="disabled">
@@ -105,11 +105,7 @@ export default {
 
   computed: {
     checkFieldName () {
-      if (this.disabled) {
-        return null
-      }
-
-      return this.value.name.length > 1 && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(this.value.name) ? null : false
+      return (this.disabled || this.value.nameValid()) ? null : false
     },
 
     disabled () {

--- a/src/lib/field/index.js
+++ b/src/lib/field/index.js
@@ -1,5 +1,6 @@
 import * as kinds from './loader'
 import i18next from 'i18next'
+import { fieldValid, nameValid } from 'corteza-webapp-common/src/lib/types/compose/module-field'
 
 const stdEmptyCheck = (value) => {
   if (Array.isArray(value)) {
@@ -98,6 +99,14 @@ export default class Field {
     }
 
     return []
+  }
+
+  get nameValid () {
+    return nameValid
+  }
+
+  get fieldValid () {
+    return fieldValid
   }
 
   // Are there any properties defined inside options object?

--- a/src/views/Admin/Modules/Edit.vue
+++ b/src/views/Admin/Modules/Edit.vue
@@ -82,6 +82,7 @@
     <editor-toolbar :back-link="{name: 'admin.modules'}"
                     :hideDelete="!module.canDeleteModule"
                     :hideSave="!module.canUpdateModule"
+                    :disable-save="!fieldsValid"
                     @delete="handleDelete"
                     @save="handleSave()"
                     @saveAndClose="handleSave({ closeOnSuccess: true })">
@@ -137,6 +138,19 @@ export default {
   computed: {
     handleState () {
       return handleState(this.module)
+    },
+
+    fieldsValid () {
+      return this.module.fields.reduce((acc, f) => {
+        const fv = f.fieldValid()
+
+        // Allow, if any old fields are invalid (legacy support)
+        if (f.fieldID !== '0') {
+          return acc && true
+        }
+
+        return acc && fv
+      }, true)
     },
 
     modalTitle () {

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -19,6 +19,9 @@ export const shallowMount = (component, { mocks = {}, stubs = [], ...options } =
     localVue,
     stubs: ['router-view', 'router-link', ...stubs],
     mixins: [ alertMixin ],
+    directives: {
+      'b-tooltip': () => {},
+    },
     mocks: {
       $t: (e) => e,
       $SystemAPI: {},

--- a/tests/unit/specs/views/Admin/Modules/edit.spec.js
+++ b/tests/unit/specs/views/Admin/Modules/edit.spec.js
@@ -1,0 +1,76 @@
+/* eslint-disable */
+/* ESLint didn't like some expects */
+
+import { expect } from 'chai'
+import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
+import Edit from 'corteza-webapp-compose/src/views/Admin/Modules/Edit.vue'
+import Field from 'corteza-webapp-common/src/lib/types/compose/module-field'
+import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
+import Module from 'corteza-webapp-compose/src/lib/module'
+import sinon from 'sinon'
+
+describe('views/Admin/Modules/Edit.vue', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  let propsData
+  beforeEach(() => {
+    propsData = {
+      namespace: new Namespace({ namespaceID: '999' }) ,
+      moduleID: '123',
+    }
+  })
+
+  const mountEdit = (opt) => shallowMount(Edit, {
+    mocks: {},
+    propsData,
+    ...opt,
+  })
+
+  describe('validates module fields', () => {
+    beforeEach(() => {
+      sinon.stub(Edit, 'created')
+    })
+
+    it('invalid if any **new** field is invalid', () => {
+      const cases = [
+        [ new Field({ name: '', kind: 'String' }), ],
+      ]
+
+      const wrap = mountEdit()
+
+      for (const fields of cases) {
+        wrap.setData({ module: new Module({ fields }) })
+        expect(wrap.vm.fieldsValid).to.be.false
+      }
+    })
+
+    it('allow old invalid fields -- legacy support', () => {
+      const cases = [
+        [ new Field({ fieldID: '9748', name: '', kind: 'String' }), ],
+      ]
+
+      const wrap = mountEdit()
+
+      for (const fields of cases) {
+        wrap.setData({ module: new Module({ fields }) })
+        expect(wrap.vm.fieldsValid).to.be.true
+      }
+    })
+
+    it('allow valid new and old fields', () => {
+      const cases = [
+        [ new Field({ fieldID: '9748', name: 'f1', kind: 'String' }), ],
+        [ new Field({ name: 'f2', kind: 'String' }), ],
+      ]
+
+      const wrap = mountEdit()
+
+      for (const fields of cases) {
+        wrap.setData({ module: new Module({ fields }) })
+        expect(wrap.vm.fieldsValid).to.be.true
+      }
+    })
+  })
+})


### PR DESCRIPTION
Prevent users from creating module fields with invalid names/labels. Previously I could have easily made a module field with an empty name.