### PR TITLE
Add namespace onboarding

### DIFF
--- a/src/components/Admin/Module/FieldRowView.vue
+++ b/src/components/Admin/Module/FieldRowView.vue
@@ -4,9 +4,6 @@
     <td>{{ field.name }}</td>
     <td>{{ field.label }}</td>
     <td>{{ field.kind }}</td>
-    <td class="text-center"></td>
-    <td class="text-center"></td>
-    <td class="text-center"></td>
   </tr>
 </template>
 

--- a/src/components/Admin/Page/Tree.vue
+++ b/src/components/Admin/Page/Tree.vue
@@ -44,6 +44,7 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
 import SortableTree from 'vue-sortable-tree'
 import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
 
@@ -89,6 +90,10 @@ export default {
   },
 
   methods: {
+    ...mapActions({
+      updatePage: 'page/update',
+    }),
+
     handleChangePosition ({ beforeParent, data, afterParent }) {
       const { namespaceID } = this.namespace
       const beforeID = beforeParent.parent ? beforeParent.pageID : '0'
@@ -109,7 +114,7 @@ export default {
         data.selfID = afterID
         data.namespaceID = namespaceID
 
-        this.$ComposeAPI.pageUpdate(data).then(() => {
+        this.updatePage(data).then(() => {
           reorder()
         }).catch(this.defaultErrorHandler(this.$t('notification.page.pageMoveFailed')))
       } else {

--- a/src/components/Common/CircleStep.vue
+++ b/src/components/Common/CircleStep.vue
@@ -43,7 +43,7 @@ export default {
   computed: {
     popoverContent () {
       if (this.optional) {
-        return 'This step is optional!'
+        return this.$t('onboarding.step.optional')
       } else {
         // If popover content is an empty string it doesnt show
         return ''

--- a/src/components/Common/CircleStep.vue
+++ b/src/components/Common/CircleStep.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <div :class="{ 'disabled': disabled, 'small': small }"
+         class="h3 mx-auto rounded-circle circle border-primary text-primary text-center mb-5"
+         v-b-popover.hover.top="popoverContent">
+      <font-awesome-icon v-if="done" :icon="['fas', 'check']" />
+      <span v-else>{{ stepNumber }}</span>
+    </div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    done: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    optional: {
+      type: Boolean,
+      default: false,
+    },
+
+    stepNumber: {
+      type: String,
+      default: '?',
+    },
+
+    small: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  computed: {
+    popoverContent () {
+      if (this.optional) {
+        return 'This step is optional!'
+      } else {
+        // If popover content is an empty string it doesnt show
+        return ''
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.circle {
+  width: 75px;
+  height: 75px;
+  font-size: 35px;
+  line-height: 75px;
+  border: 2px solid;
+}
+
+.small {
+  width: 50px;
+  height: 50px;
+  font-size: 25px;
+  line-height: 50px;
+}
+
+.disabled {
+  opacity: 0.65;
+}
+</style>

--- a/src/components/Public/Header.vue
+++ b/src/components/Public/Header.vue
@@ -30,7 +30,7 @@
         <div id="right-nav-opts"
              class="position-absolute d-flex align-items-center">
           <router-link v-if="namespace.canManageNamespace"
-                      :to="{ name: 'admin' }"
+                      :to="{ name: 'admin.modules' }"
                       class="nav-link mw-100 text-nowrap">{{ $t('navigation.adminPanel') }}</router-link>
 
           <hamburger-menu class="d-none d-md-block mr-2"

--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -240,6 +240,8 @@ export default {
     newLabel: 'Create a new module:',
     newPlaceholder: '$t(general.label.moduleName)',
     recordPage: 'Record page for module',
+    recordListPage: 'Record List page for module',
+    recordList: 'Record List for module',
     import: 'Import module(s):',
     edit: {
       title: 'Edit module',

--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -14,7 +14,7 @@ export default {
     message: {
       noPages: 'It seems this namespace has no visible pages yet.',
       startBuilding: 'Follow these steps to start building',
-      notifyAdministrator: 'Notify your system administrator',
+      notifyAdministrator: 'Notify your system administrator.',
     },
     step: {
       optional: 'This step is optional!',

--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -10,6 +10,28 @@ export default {
     adminPanel: 'Admin panel',
     more: 'More',
   },
+  onboarding: {
+    message: {
+      noPages: 'It seems this namespace has no visible pages yet.',
+      startBuilding: 'Follow these steps to start building',
+      notifyAdministrator: 'Notify your system administrator',
+    },
+    step: {
+      optional: 'This step is optional!',
+      module: {
+        create: 'Create Module',
+        view: 'Your Modules',
+      },
+      chart: {
+        create: 'Make Chart',
+        view: 'Your Charts',
+      },
+      page: {
+        create: 'Build Page',
+        view: 'Your Pages',
+      },
+    },
+  },
   block: {
     general: {
       title: 'Add new block',
@@ -239,10 +261,12 @@ export default {
     title: 'List of modules',
     newLabel: 'Create a new module:',
     newPlaceholder: '$t(general.label.moduleName)',
-    recordPage: 'Record page for module',
-    recordListPage: 'Record List page for module',
-    recordList: 'Record List for module',
     import: 'Import module(s):',
+    forModule: {
+      recordPage: 'Record page for module',
+      recordListPage: 'Record List page for module',
+      recordList: 'Record List for module',
+    },
     edit: {
       title: 'Edit module',
       manageRecordFields: 'Manage record fields',
@@ -257,6 +281,16 @@ export default {
         multi: 'Allows the field to hold multiple values',
         required: 'Required field',
         private: 'Sensitive data',
+      },
+      step: {
+        recordList: {
+          create: 'Create Record List',
+          view: 'Record List Page',
+        },
+        recordPage: {
+          create: 'Create Record Page',
+          view: 'Module Record Page',
+        },
       },
     },
     recordGenerator: {
@@ -519,6 +553,7 @@ export default {
       handle: 'Handle',
       general: 'General',
       enabled: 'Enabled',
+      welcome: 'Welcome',
     },
     placeholder: {
       handle: 'handle (a - z, 0 - 9, underscore, dash)',

--- a/src/lib/page.js
+++ b/src/lib/page.js
@@ -22,6 +22,10 @@ export default class Page {
     this.canGrant = typeof args.canGrant === 'boolean' ? args.canGrant : false
   }
 
+  isRecordPage () {
+    return this.moduleID !== '0' && this.moduleID
+  }
+
   export () {
     return {
       title: this.title,

--- a/src/stories/setup.js
+++ b/src/stories/setup.js
@@ -9,7 +9,7 @@ import SystemAPI from './system'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import '../themes/corteza-base/index.scss'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faSort, faSortUp, faSortDown, faWrench, faGripVertical, faDownload, faFileExport, faSearch, faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faSort, faSortUp, faSortDown, faWrench, faGripVertical, faDownload, faFileExport, faSearch, faBars, faTimes, faCheck, faExclamation } from '@fortawesome/free-solid-svg-icons'
 import { faEye, faFileAlt, faFileWord, faFilePdf, faFilePowerpoint, faFileArchive, faFileExcel, faFileVideo, faFileImage, faEdit, faTrashAlt } from '@fortawesome/free-regular-svg-icons'
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)
@@ -37,14 +37,12 @@ library.add(
   faSearch,
   faBars,
   faTimes,
+  faCheck,
 )
+library.add(faExclamation)
 
 Vue.use(BootstrapVue)
 Vue.use(Vuex)
 
 Vue.prototype.$ComposeAPI = ComposeAPI
 Vue.prototype.$SystemAPI = SystemAPI
-
-Vue.prototype.$auth = {
-  JWT: '',
-}

--- a/src/stories/setup.js
+++ b/src/stories/setup.js
@@ -9,7 +9,7 @@ import SystemAPI from './system'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import '../themes/corteza-base/index.scss'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faSort, faSortUp, faSortDown, faWrench, faGripVertical, faDownload, faFileExport, faSearch, faBars, faTimes, faCheck, faExclamation } from '@fortawesome/free-solid-svg-icons'
+import { faSort, faSortUp, faSortDown, faWrench, faGripVertical, faDownload, faFileExport, faSearch, faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { faEye, faFileAlt, faFileWord, faFilePdf, faFilePowerpoint, faFileArchive, faFileExcel, faFileVideo, faFileImage, faEdit, faTrashAlt } from '@fortawesome/free-regular-svg-icons'
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)
@@ -37,12 +37,14 @@ library.add(
   faSearch,
   faBars,
   faTimes,
-  faCheck,
 )
-library.add(faExclamation)
 
 Vue.use(BootstrapVue)
 Vue.use(Vuex)
 
 Vue.prototype.$ComposeAPI = ComposeAPI
 Vue.prototype.$SystemAPI = SystemAPI
+
+Vue.prototype.$auth = {
+  JWT: '',
+}

--- a/src/views/Admin/Modules/Edit.vue
+++ b/src/views/Admin/Modules/Edit.vue
@@ -67,8 +67,12 @@
                   <b-row align-v="center" class="text-center justify-content-between mt-4">
                     <b-col>
                       <circle-step stepNumber="1" :done="!!recordListPage" small>
-                        <b-button v-if="!recordListPage" @click="handleRecordListCreation" :disabled="!namespace.canCreatePage" variant="outline-primary">
-                          Create Record List
+                        <b-button v-if="!recordListPage"
+                                  @click="handleRecordListCreation"
+                                  :disabled="!namespace.canCreatePage"
+                                  variant="outline-primary">
+
+                          {{ $t('module.edit.step.recordList.create') }}
                         </b-button>
                         <confirm v-else
                                 @confirmed="toRecordList('view')"
@@ -81,7 +85,7 @@
                                 size="md"
                                 sizeConfirm="md">
 
-                          Record List Page
+                          {{ $t('module.edit.step.recordList.view') }}
                           <template v-slot:yes>
                             {{ $t('general.label.view') }}
                           </template>
@@ -97,11 +101,11 @@
                     <b-col>
                       <circle-step stepNumber="2" :done="!!recordPage" :disabled="!recordListPage" small>
                         <b-button v-if="!recordPage" @click="handleRecordPageCreation" variant="outline-primary">
-                          Create Record Page
+                          {{ $t('module.edit.step.recordPage.create') }}
                         </b-button>
                         <router-link v-else :to="{ name: 'admin.pages.builder', params: { pageID: recordPage.pageID } }">
                           <b-button :disabled="!namespace.canManageNamespace" variant="primary">
-                            Module Record Page
+                            {{ $t('module.edit.step.recordPage.view') }}
                           </b-button>
                         </router-link>
                       </circle-step>
@@ -298,7 +302,7 @@ export default {
 
       const payload = {
         namespaceID,
-        title: `${this.$t('module.recordPage')} "${name || moduleID}"`,
+        title: `${this.$t('module.forModule.recordPage')} "${name || moduleID}"`,
         moduleID,
         selfID: this.recordListPage.pageID,
         blocks: [],
@@ -315,7 +319,7 @@ export default {
 
       const payload = {
         namespaceID,
-        title: `${this.$t('module.recordListPage')} "${name || moduleID}"`,
+        title: `${this.$t('module.forModule.recordListPage')} "${name || moduleID}"`,
         selfID: '0',
         blocks: [],
       }
@@ -323,7 +327,7 @@ export default {
       this.createPage(payload).then(page => {
         this.recordList.pageID = page.pageID
         this.recordList.fields = []
-        this.recordList.title = `${this.$t('module.recordList')} "${name || moduleID}"`
+        this.recordList.title = `${this.$t('module.forModule.recordList')} "${name || moduleID}"`
         const blocks = [
           new Block({
             xywh: [0, 0, 12, 16],

--- a/src/views/Admin/Modules/Index.vue
+++ b/src/views/Admin/Modules/Index.vue
@@ -122,7 +122,7 @@ export default {
     const { namespaceID } = this.namespace
 
     return {
-      newModule: new Module({ namespaceID, fields: [new Field({ fieldID: '0', name: 'sample', kind: 'String' })] }),
+      newModule: new Module({ namespaceID, fields: [new Field({ fieldID: '0', name: 'Sample', kind: 'String' })] }),
     }
   },
 

--- a/src/views/Admin/Modules/Index.vue
+++ b/src/views/Admin/Modules/Index.vue
@@ -169,7 +169,7 @@ export default {
       const { namespaceID } = this.namespace
       const payload = {
         namespaceID,
-        title: `${this.$t('module.recordPage')} "${module.name || moduleID}"`,
+        title: `${this.$t('module.forModule.recordPage')} "${module.name || moduleID}"`,
         moduleID,
         blocks: [],
       }

--- a/src/views/Admin/Pages/Builder.vue
+++ b/src/views/Admin/Pages/Builder.vue
@@ -134,6 +134,7 @@ export default {
     ...mapActions({
       findPageByID: 'page/findByID',
       updatePage: 'page/update',
+      deletePage: 'page/delete',
     }),
 
     editBlock (block, index = undefined) {
@@ -172,7 +173,7 @@ export default {
     },
 
     handleDeletePage () {
-      this.$ComposeAPI.pageDelete(this.page).then(() => {
+      this.deletePage(this.page).then(() => {
         this.$router.push({ name: 'admin.pages' })
       }).catch(this.defaultErrorHandler(this.$t('notification.page.deleteFailed')))
     },

--- a/src/views/Admin/Pages/Edit.vue
+++ b/src/views/Admin/Pages/Edit.vue
@@ -44,6 +44,7 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
 import ConfirmationToggle from 'corteza-webapp-compose/src/components/Admin/ConfirmationToggle'
 import EditorToolbar from 'corteza-webapp-compose/src/components/Admin/EditorToolbar'
 import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
@@ -85,8 +86,8 @@ export default {
 
   created () {
     const { namespaceID } = this.namespace
-    this.$ComposeAPI.pageRead({ namespaceID, pageID: this.pageID }).then((page) => {
-      if (page.moduleID !== '0') {
+    this.findPageByID({ namespaceID, pageID: this.pageID }).then((page) => {
+      if (page.isRecordPage()) {
         // Do not allow to edit record pages, move to builder
         this.$router.replace({ name: 'admin.pages.builder', params: { pageID: page.pageID } })
       }
@@ -95,9 +96,14 @@ export default {
     }).catch(this.defaultErrorHandler(this.$t('notification.page.loadFailed')))
   },
   methods: {
+    ...mapActions({
+      findPageByID: 'page/findByID',
+      updatePage: 'page/update',
+      deletePage: 'page/delete',
+    }),
     handleSave ({ closeOnSuccess = false } = {}) {
       const { namespaceID } = this.namespace
-      this.$ComposeAPI.pageUpdate({ namespaceID, ...this.page }).then((page) => {
+      this.updatePage({ namespaceID, ...this.page }).then((page) => {
         this.page = new Page(page)
         this.raiseSuccessAlert(this.$t('notification.page.saved'))
         if (closeOnSuccess) {
@@ -107,7 +113,7 @@ export default {
     },
 
     handleDeletePage () {
-      this.$ComposeAPI.pageDelete(this.page).then(() => {
+      this.deletePage(this.page).then(() => {
         this.$router.push({ name: 'admin.pages' })
       }).catch(this.defaultErrorHandler(this.$t('notification.page.deleteFailed')))
     },

--- a/src/views/Admin/Pages/Index.vue
+++ b/src/views/Admin/Pages/Index.vue
@@ -41,6 +41,7 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex'
 import draggable from 'vuedraggable'
 import PageTree from 'corteza-webapp-compose/src/components/Admin/Page/Tree'
 import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
@@ -75,6 +76,10 @@ export default {
   },
 
   methods: {
+    ...mapActions({
+      createPage: 'page/create',
+    }),
+
     loadTree () {
       const { namespaceID } = this.namespace
       this.$ComposeAPI.pageTree({ namespaceID }).then((tree) => {
@@ -84,7 +89,7 @@ export default {
 
     handleAddPageFormSubmit () {
       const { namespaceID } = this.namespace
-      this.$ComposeAPI.pageCreate({ namespaceID, ...this.addPageFormData }).then((page) => {
+      this.createPage({ namespaceID, ...this.addPageFormData }).then((page) => {
         this.$router.push({ name: 'admin.pages.edit', params: { pageID: page.pageID } })
       }).catch(this.defaultErrorHandler(this.$t('notification.page.saveFailed')))
     },

--- a/src/views/Public/Index.vue
+++ b/src/views/Public/Index.vue
@@ -14,7 +14,7 @@
           {{ $t('onboarding.message.notifyAdministrator') }}
         </span>
       </p>
-      <b-container v-if="namespace.canManageNamespace" fluid class="align-items-center border-top steps">
+      <b-container v-if="namespace.canManageNamespace" fluid class="align-items-center p-0 border-top steps">
         <b-row align-v="center" class="text-center justify-content-between">
           <b-col>
             <circle-step stepNumber="1" :done="hasModules">
@@ -143,7 +143,7 @@ export default {
     },
 
     hasPages () {
-      return !!this.pages.filter(p => p.visible).length
+      return this.pages.filter(p => p.visible).length > 0
     },
   },
 
@@ -204,7 +204,6 @@ export default {
 </script>
 <style lang="scss" scoped>
 .steps {
-  padding: 0;
   padding-top: 20vh;
 }
 </style>

--- a/src/views/Public/Index.vue
+++ b/src/views/Public/Index.vue
@@ -3,15 +3,75 @@
     <public-header :page="page"
                    :namespace="namespace"
                    @toggleNav="navVisible = $event" />
-    <router-view :namespace="namespace"
+    <div v-if="showSteps" class="d-flex flex-column m-5 vh-75">
+      <h1 class="display-3">Welcome!</h1>
+      <p class="lead">
+        It seems this namespace is not yet configured. Follow these steps to start building.
+      </p>
+      <b-container fluid class="align-items-center border-top steps">
+        <b-row align-v="center" class="text-center justify-content-between">
+          <b-col>
+            <div class="mx-auto circle border-primary text-primary">
+              <font-awesome-icon v-if="hasModules" :icon="['fas', 'check']" />
+              <span v-else>1</span>
+            </div>
+            <b-button v-if="!hasModules" @click="createNewModule" :disabled="!namespace.canCreateModule" variant="outline-primary mt-5" size="lg">
+              Create Module
+            </b-button>
+            <router-link v-else-if="namespace.canManageNamespace" :to="{ name: 'admin.modules' }">
+              <b-button variant="primary mt-5" size="lg">
+                Your Modules
+              </b-button>
+            </router-link>
+          </b-col>
+          <b-col>
+            <hr />
+          </b-col>
+          <b-col>
+            <div class="mx-auto circle border-primary text-primary" v-b-popover.hover.top="'This step is optional!'" :class="{ 'disabled-step': !hasCharts }">
+              <font-awesome-icon v-if="hasCharts" :icon="['fas', 'check']" />
+              <span v-else>?</span>
+            </div>
+            <div v-if="!hasCharts" class="d-flex justify-content-center align-items-center mt-5">
+              <b-button @click="createNewChart" :disabled="!hasModules || !namespace.canCreateChart" variant="outline-primary" size="lg">
+                Make Chart
+              </b-button>
+            </div>
+            <router-link v-else-if="namespace.canManageNamespace" :to="{ name: 'admin.charts' }">
+              <b-button variant="primary mt-5" size="lg">
+                Your Charts
+              </b-button>
+            </router-link>
+          </b-col>
+          <b-col>
+            <hr />
+          </b-col>
+          <b-col>
+            <div class="mx-auto circle border-primary text-primary" :class="{ 'disabled-step': !hasModules }">
+              <font-awesome-icon v-if="hasPages" :icon="['fas', 'check']" />
+              <span v-else>2</span>
+            </div>
+            <b-button v-if="!hasPages" @click="createNewPage" :disabled="!hasModules || !namespace.canCreatePage" variant="outline-primary mt-5" size="lg">
+              Build Page
+            </b-button>
+          </b-col>
+        </b-row>
+      </b-container>
+    </div>
+    <router-view v-else
+                 :namespace="namespace"
                  :page="page" />
   </div>
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex'
 import PublicHeader from 'corteza-webapp-compose/src/components/Public/Header'
 import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
+import Module from 'corteza-webapp-compose/src/lib/module'
+import Chart from 'corteza-webapp-compose/src/lib/chart'
 import Page from 'corteza-webapp-compose/src/lib/page'
+import Field from 'corteza-webapp-compose/src/lib/field'
 
 const pushContentAbove = 610
 
@@ -43,6 +103,12 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      modules: 'module/set',
+      pages: 'page/set',
+      charts: 'chart/set',
+    }),
+
     routerViewClass () {
       return {
         'compose-content': true,
@@ -56,6 +122,22 @@ export default {
 
     page () {
       return this.$store.getters['page/getByID'](this.pageID) || new Page()
+    },
+
+    showSteps () {
+      return !this.pageID && (!this.hasModules || !this.hasPages)
+    },
+
+    hasModules () {
+      return !!this.modules.length
+    },
+
+    hasCharts () {
+      return !!this.charts.length
+    },
+
+    hasPages () {
+      return !!this.pages.length
     },
   },
 
@@ -74,5 +156,61 @@ export default {
       }
     }
   },
+
+  methods: {
+    ...mapActions({
+      createModule: 'module/create',
+      createPage: 'page/create',
+      createChart: 'chart/create',
+    }),
+
+    createNewModule () {
+      const { namespaceID } = this.namespace
+      const name = 'Demo Module'
+      const newModule = new Module({ namespaceID, name, fields: [new Field({ fieldID: '0', name: 'Sample', kind: 'String' })] })
+      this.createModule(newModule).then((module) => {
+        this.$router.push({ name: 'admin.modules.edit', params: { moduleID: module.moduleID } })
+      }).catch(this.defaultErrorHandler(this.$t('notification.module.createFailed')))
+    },
+
+    createNewChart () {
+      const { namespaceID } = this.namespace
+      const name = 'Demo Chart'
+      const newChart = new Chart({ namespaceID, name })
+      this.createChart(newChart).then((chart) => {
+        this.$router.push({ name: 'admin.charts.edit', params: { chartID: chart.chartID } })
+      }).catch(this.defaultErrorHandler(this.$t('notification.chart.createFailed')))
+    },
+
+    createNewPage () {
+      const { namespaceID } = this.namespace
+      const title = 'Test Page'
+      const blocks = []
+      const newPage = new Page({ namespaceID, title, blocks })
+      this.createPage(newPage).then((page) => {
+        this.$router.push({ name: 'admin.pages.builder', params: { pageID: page.pageID } })
+      }).catch(this.defaultErrorHandler(this.$t('notification.page.saveFailed')))
+    },
+  },
 }
 </script>
+<style lang="scss" scoped>
+.circle {
+  width: 75px;
+  height: 75px;
+  border-radius: 50%;
+  font-size: 35px;
+  line-height: 75px;
+  text-align: center;
+  border: 2px solid;
+}
+
+.steps {
+  padding: 0;
+  padding-top: 20vh;
+}
+
+.disabled-step {
+  opacity: 0.65;
+}
+</style>

--- a/src/views/Public/Index.vue
+++ b/src/views/Public/Index.vue
@@ -4,14 +4,14 @@
                    :namespace="namespace"
                    @toggleNav="navVisible = $event" />
     <div v-if="showSteps" class="d-flex flex-column m-5 vh-75">
-      <h1 class="display-3">Welcome!</h1>
+      <h1 class="display-3">{{ $t('general.label.welcome') }}!</h1>
       <p class="lead">
-        It seems this namespace has no visible pages yet.
+        {{ $t('onboarding.message.noPages') }}
         <span v-if="namespace.canManageNamespace">
-          Follow these steps to start building.
+          {{ $t('onboarding.message.startBuilding') }}
         </span>
         <span v-else>
-          Notify your system administrator!
+          {{ $t('onboarding.message.notifyAdministrator') }}
         </span>
       </p>
       <b-container v-if="namespace.canManageNamespace" fluid class="align-items-center border-top steps">
@@ -19,11 +19,11 @@
           <b-col>
             <circle-step stepNumber="1" :done="hasModules">
               <b-button v-if="!hasModules" @click="createNewModule" :disabled="!namespace.canCreateModule" variant="outline-primary" size="lg">
-                Create Module
+                {{ $t('onboarding.step.module.create') }}
               </b-button>
               <router-link v-else :to="{ name: 'admin.modules' }">
                 <b-button :disabled="!namespace.canManageNamespace" variant="primary" size="lg">
-                  Your Modules
+                {{ $t('onboarding.step.module.view') }}
                 </b-button>
               </router-link>
             </circle-step>
@@ -34,11 +34,11 @@
           <b-col>
             <circle-step :done="hasCharts" :disabled="!hasModules" optional>
               <b-button v-if="!hasCharts" @click="createNewChart" :disabled="!hasModules || !namespace.canCreateChart" variant="outline-primary" size="lg">
-                Make Chart
+                {{ $t('onboarding.step.chart.create') }}
               </b-button>
               <router-link v-else :to="{ name: 'admin.charts' }">
                 <b-button :disabled="!namespace.canManageNamespace" variant="primary" size="lg">
-                  Your Charts
+                {{ $t('onboarding.step.chart.view') }}
                 </b-button>
               </router-link>
             </circle-step>
@@ -49,11 +49,11 @@
           <b-col>
             <circle-step stepNumber="2" :done="hasPages" :disabled="!hasModules">
               <b-button v-if="!hasPages" @click="createNewPage" :disabled="!hasModules || !namespace.canCreatePage" variant="outline-primary" size="lg">
-                Build Page
+                {{ $t('onboarding.step.page.create') }}
               </b-button>
               <router-link v-else :to="{ name: 'admin.pages' }">
                 <b-button :disabled="!namespace.canManageNamespace" variant="primary" size="lg">
-                  Your Pages
+                {{ $t('onboarding.step.page.view') }}
                 </b-button>
               </router-link>
             </circle-step>

--- a/tests/unit/specs/views/Admin/Modules/edit.spec.js
+++ b/tests/unit/specs/views/Admin/Modules/edit.spec.js
@@ -2,18 +2,33 @@
 /* ESLint didn't like some expects */
 
 import { expect } from 'chai'
+import { createLocalVue } from '@vue/test-utils'
 import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
 import Edit from 'corteza-webapp-compose/src/views/Admin/Modules/Edit.vue'
 import Field from 'corteza-webapp-common/src/lib/types/compose/module-field'
 import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
 import Module from 'corteza-webapp-compose/src/lib/module'
 import EditorToolbar from 'corteza-webapp-compose/src/components/Admin/EditorToolbar'
+import Vuex from 'vuex'
 import sinon from 'sinon'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
 
 describe('views/Admin/Modules/Edit.vue', () => {
   afterEach(() => {
     sinon.restore()
   })
+
+  const store = new Vuex.Store({ modules: { page: {
+    namespaced: true,
+    state: {},
+    getters: {
+      set: () => {
+        return []
+      }
+    }
+  }}})
 
   let propsData
   beforeEach(() => {
@@ -24,6 +39,8 @@ describe('views/Admin/Modules/Edit.vue', () => {
   })
 
   const mountEdit = (opt) => shallowMount(Edit, {
+    store,
+    localVue,
     mocks: {},
     propsData,
     ...opt,

--- a/tests/unit/specs/views/Public/index.spec.js
+++ b/tests/unit/specs/views/Public/index.spec.js
@@ -1,0 +1,226 @@
+/* eslint-disable */
+/* ESLint didn't like some expects */
+
+import { expect } from 'chai'
+import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
+import { createLocalVue } from '@vue/test-utils'
+import Index from 'corteza-webapp-compose/src/views/Public/Index'
+import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
+import Module from 'corteza-webapp-compose/src/lib/module'
+import Page from 'corteza-webapp-compose/src/lib/page'
+import Chart from 'corteza-webapp-compose/src/lib/chart'
+import sinon from 'sinon'
+import Vuex from 'vuex'
+
+const localVue = createLocalVue()
+
+localVue.use(Vuex)
+
+describe('views/Public/Index.vue', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  let propsData
+  let store = new Vuex.Store({
+    modules: {
+      page: {
+        namespaced: true,
+        state: {
+          set: [],
+        },
+        getters: {
+          set: () => {
+            return []
+          },
+          getByID: () => {
+            return () => undefined
+          }
+        }
+      },
+      module: {
+        namespaced: true,
+        state: {
+          set: [],
+        },
+        getters: {
+          set: () => {
+            return []
+          },
+        }
+      },
+      chart: {
+        namespaced: true,
+        state: {
+          set: [],
+        },
+        getters: {
+          set: () => {
+            return []
+          },
+        }
+      }
+    }
+  })
+
+  beforeEach(() => {
+    propsData = {
+      namespace: new Namespace({ namespaceID: '000' }),
+      pageID: '',
+    }
+  })
+
+  const mountIndex = (opt) => shallowMount(Index, {
+    store,
+    localVue,
+    propsData,
+    ...opt,
+  })
+
+  describe('Onboarding', () => {
+    it('will show steps when needed', () => {
+      const wrapShow = mountIndex()
+
+      expect(wrapShow.vm.showSteps).to.be.true
+      expect(wrapShow.vm.hasModules).to.be.false
+      expect(wrapShow.vm.hasPages).to.be.false
+      expect(wrapShow.vm.hasCharts).to.be.false
+
+      propsData.pageID = '123'
+      const wrapHide = mountIndex()
+
+      expect(wrapHide.vm.showSteps).to.be.false
+      expect(wrapHide.vm.hasModules).to.be.false
+      expect(wrapHide.vm.hasPages).to.be.false
+      expect(wrapHide.vm.hasCharts).to.be.false
+    })
+
+    
+    it('will detect step 1', () => {
+      store = new Vuex.Store({
+        modules: {
+          page: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return []
+              },
+              getByID: () => {
+                return () => undefined
+              }
+            }
+          },
+          module: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Module()]
+              },
+            }
+          },
+          chart: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return []
+              },
+            }
+          }
+        }
+      })
+      const wrap = mountIndex()
+      
+      expect(wrap.vm.hasModules).to.be.true
+      expect(wrap.vm.hasCharts).to.be.false
+      expect(wrap.vm.hasPages).to.be.false
+    })
+
+    it('will detect step 2', () => {
+      store = new Vuex.Store({
+        modules: {
+          page: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return []
+              },
+              getByID: () => {
+                return () => undefined
+              }
+            }
+          },
+          module: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Module()]
+              },
+            }
+          },
+          chart: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Chart()]
+              },
+            }
+          }
+        }
+      })
+      const wrap = mountIndex()
+      
+      expect(wrap.vm.hasModules).to.be.true
+      expect(wrap.vm.hasCharts).to.be.true
+      expect(wrap.vm.hasPages).to.be.false
+    })
+
+
+    it('will detect step 3', () => {
+      store = new Vuex.Store({
+        modules: {
+          page: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Page()]
+              },
+              getByID: () => {
+                return () => undefined
+              }
+            }
+          },
+          module: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Module()]
+              },
+            }
+          },
+          chart: {
+            namespaced: true,
+            state: {},
+            getters: {
+              set: () => {
+                return [new Chart()]
+              },
+            }
+          }
+        }
+      })
+      const wrap = mountIndex()
+      
+      expect(wrap.vm.hasModules).to.be.true
+      expect(wrap.vm.hasCharts).to.be.true
+      expect(wrap.vm.hasPages).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
Step 1, takes user to module edit with prefilled name and sample field:
![Screenshot from 2019-10-15 18-35-59](https://user-images.githubusercontent.com/15791641/66851328-d039ac80-ef7a-11e9-9c7d-faf0a8df34ff.png)

Step 2 (Optional), takes user to chart edit with prefilled name:
![OnPaste 20191015-183703](https://user-images.githubusercontent.com/15791641/66851341-d7f95100-ef7a-11e9-875f-9bd8c7c445c5.png)

Step 3, takes user to page builder:
![Screenshot from 2019-10-15 18-36-38](https://user-images.githubusercontent.com/15791641/66851356-df205f00-ef7a-11e9-8741-3b9e67f258b9.png)



Updated modules edit screen:
If the module has no record or recordList page:
![Screenshot from 2019-10-17 14-27-02](https://user-images.githubusercontent.com/15791641/67008817-a1424880-f0ea-11e9-95bd-50cc6bf256b7.png)

If a recordList page exists:
![Screenshot from 2019-10-17 14-27-18](https://user-images.githubusercontent.com/15791641/67008840-aef7ce00-f0ea-11e9-97ed-3fe2ccc45738.png)

If 'Record List Page' button is clicked:
![Screenshot from 2019-10-17 14-27-29](https://user-images.githubusercontent.com/15791641/67008889-c3d46180-f0ea-11e9-8fb6-113293a27d53.png)

Creates page with fullscreen recordList block(module prefilled, no fields selected):
![Screenshot from 2019-10-17 14-26-20](https://user-images.githubusercontent.com/15791641/67009029-07c76680-f0eb-11e9-91cd-db5b6d0d9a8d.png)

After creating both pages using buttons:
![Screenshot from 2019-10-17 14-26-01](https://user-images.githubusercontent.com/15791641/67008969-ea929800-f0ea-11e9-9a04-91c4256ee486.png)

If Both record and recordList pages exist:
![Screenshot from 2019-10-17 14-27-42](https://user-images.githubusercontent.com/15791641/67008926-d484d780-f0ea-11e9-9858-18360a2d5d39.png)
