### PR TITLE
Allow labels for select options

### DIFF
--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -815,7 +815,8 @@ export default {
         optionsLabel: 'Options to select from',
         optionRemove: 'Remove',
         optionAdd: 'Add',
-        optionPlaceholder: 'Add more',
+        optionValuePlaceholder: 'Value',
+        optionLabelPlaceholder: 'Label',
         optionType: {
           label: 'Multiple value input type',
           default: 'Single input',

--- a/src/lib/field/Configurator/Select.vue
+++ b/src/lib/field/Configurator/Select.vue
@@ -7,8 +7,15 @@
                        class="mb-1"
                        :key="index">
           <b-form-input plain
-                        v-model="f.options.options[index]"
-                        size="sm"></b-form-input>
+                        v-model="f.options.options[index].value"
+                        size="sm"
+                        :placeholder="$t('field.kind.select.optionValuePlaceholder')" />
+
+          <b-form-input plain
+                        v-model="f.options.options[index].text"
+                        size="sm"
+                        :placeholder="$t('field.kind.select.optionLabelPlaceholder')" />
+
           <b-input-group-append>
             <b-button @click.prevent="f.options.options.splice(index, 1)"
                       variant="outline-danger"
@@ -19,12 +26,25 @@
         </b-input-group>
 
         <b-input-group>
-          <b-form-input plain v-model="newOption" @keypress.enter.prevent="handleAddOption" size="sm" :placeholder="$t('field.kind.select.optionRemove')"></b-form-input>
+          <b-form-input plain
+                        v-model="newOption.value"
+                        @keypress.enter.prevent="handleAddOption"
+                        size="sm"
+                        :placeholder="$t('field.kind.select.optionValuePlaceholder')"
+                        :state="newOptState" />
+
+          <b-form-input plain
+                        v-model="newOption.text"
+                        @keypress.enter.prevent="handleAddOption"
+                        size="sm"
+                        :placeholder="$t('field.kind.select.optionLabelPlaceholder')"
+                        :state="newOptState" />
+
           <b-input-group-append>
             <b-button @click.prevent="handleAddOption"
                       variant="primary"
                       size="sm"
-                      :disabled="newOption.length === 0">
+                      :disabled="newOptState === false || newEmpty">
               + {{ $t('field.kind.select.optionAdd') }}
             </b-button>
           </b-input-group-append>
@@ -51,13 +71,35 @@ export default {
 
   data () {
     return {
-      newOption: '',
+      newOption: { value: undefined, text: undefined },
       selectOptions: [
         { text: this.$t('field.kind.select.optionType.default'), value: 'default' },
         { text: this.$t('field.kind.select.optionType.multiple'), value: 'multiple' },
         { text: this.$t('field.kind.select.optionType.each'), value: 'each' },
       ],
     }
+  },
+
+  computed: {
+    /**
+     * Determines if newly entered option is empty
+     * @returns {Boolean}
+     */
+    newEmpty () {
+      return !this.newOption.text || !this.newOption.value
+    },
+
+    /**
+     * Determines the state of new select option
+     * @returns {Boolean|null}
+     */
+    newOptState () {
+      // No duplicates
+      if (this.f.options.options.find(({ text, value }) => text === this.newOption.text || value === this.newOption.value)) {
+        return false
+      }
+      return null
+    },
   },
 
   created () {
@@ -70,9 +112,9 @@ export default {
 
   methods: {
     handleAddOption () {
-      if (this.newOption.length > 0) {
+      if (this.newOption.value) {
         this.f.options.options.push(this.newOption)
-        this.newOption = ''
+        this.newOption = { value: undefined, text: undefined }
       }
     },
   },

--- a/src/lib/field/Editor/Select.vue
+++ b/src/lib/field/Editor/Select.vue
@@ -9,7 +9,7 @@
       </template>
       <template v-slot:default="ctx">
         <b-form-select v-if="field.options.selectType === 'each'" :options="selectOptions" v-model="value[ctx.index]" />
-        <span v-else>{{ value[ctx.index] }}</span>
+        <span v-else>{{ findLabel(value[ctx.index]) }}</span>
       </template>
     </multi>
 
@@ -40,6 +40,15 @@ export default {
       this.value.push(value)
       // Reset select
       this.$refs.singleSelect.localValue = undefined
+    },
+
+    /**
+     * Helper to resolve a label for a gievn value
+     * @param {String} v Value in question
+     * @returns {String}
+     */
+    findLabel (v) {
+      return (this.selectOptions.find(({ value }) => value === v) || {}).text || v
     },
   },
 }

--- a/src/lib/field/Select.js
+++ b/src/lib/field/Select.js
@@ -6,7 +6,7 @@ export class Select {
   }
 
   merge ({ options, selectType, multiDelimiter } = {}) {
-    this.options = options || []
+    this.options = this.prepOptions(options || [])
     this.selectType = selectType ? (typeof selectType === 'string' ? selectType : 'default') : 'default'
     this.multiDelimiter = multiDelimiter ? (typeof multiDelimiter === 'string' ? multiDelimiter : '\n') : '\n'
 
@@ -18,5 +18,21 @@ export class Select {
       options: this.options,
       selectType: this.selectType,
     }
+  }
+
+  /**
+   * Helper to prepare options for the given select
+   * @param {Array} options Array of available options
+   * @returns {Array}
+   */
+  prepOptions (options) {
+    return options.map(opt => {
+      if (typeof (opt) !== 'object') {
+        opt = { value: opt, text: opt }
+      }
+
+      opt.text = opt.text || opt.value
+      return opt
+    })
   }
 }

--- a/src/lib/field/Viewer/Select.vue
+++ b/src/lib/field/Viewer/Select.vue
@@ -1,7 +1,37 @@
 <script>
 import base from './base'
 
+/**
+ * Helper to find a label for the given value
+ * @param {String} v Value in question
+ * @param {Array<Object>} options Available options
+ * @returns {String|undefined}
+ */
+function findLabel (v, options) {
+  return (options.find(({ value }) => value === v) || {}).text
+}
+
 export default {
   extends: base,
+
+  computed: {
+    /**
+     * Overwrite default; allow values to resolve to their labels
+     * @returns {String|Array<String>}
+     */
+    value () {
+      let v
+      if (this.field.isSystem) {
+        v = this.record[this.field.name]
+      }
+      v = this.record ? this.record.values[this.field.name] : undefined
+
+      if (this.field.isMulti) {
+        return v.map(v => findLabel(v, this.field.options.options) || v)
+      } else {
+        return findLabel(v, this.field.options.options) || v
+      }
+    },
+  },
 }
 </script>

--- a/tests/unit/specs/lib/field/Configurator/select.spec.js
+++ b/tests/unit/specs/lib/field/Configurator/select.spec.js
@@ -1,0 +1,37 @@
+/* eslint-disable */
+import { expect } from 'chai'
+import Select from 'corteza-webapp-compose/src/lib/field/Configurator/Select'
+
+describe('src/lib/field/Configurator/Select.vue', () => {
+  it('determine new option\'s state', () => {
+    const tests = [
+      {
+        name: 'valid state',
+        options: [{ text: 'opt1l', value: 'opt1v' }],
+        option: { text: 'opt2l', value: 'opt2v' },
+        state: null,
+      },
+      {
+        name: 'invalid state - dup text',
+        options: [{ text: 'opt1l', value: 'opt1v' }],
+        option: { text: 'opt1l', value: 'opt2v' },
+        state: false,
+      },
+      {
+        name: 'invalid state - dup value',
+        options: [{ text: 'opt1l', value: 'opt1v' }],
+        option: { text: 'opt2l', value: 'opt1v' },
+        state: false,
+      },
+    ]
+
+    const fnc = Select.computed.newOptState
+    for (const t of tests) {
+      const local = {
+        newOption: t.option,
+        f: { options: { options: t.options } }
+      }
+      expect(fnc.call(local), t.name).to.eq(t.state)
+    }
+  })
+})

--- a/tests/unit/specs/lib/field/Editor/select.spec.js
+++ b/tests/unit/specs/lib/field/Editor/select.spec.js
@@ -1,0 +1,63 @@
+/* eslint-disable */
+import { expect } from 'chai'
+import Select from 'corteza-webapp-compose/src/lib/field/Editor/Select'
+import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
+
+describe('lib/field/Editor/Select.vue', () => {
+  let propsData
+  beforeEach(() => {
+    propsData = {
+      namespace: {
+        namespaceID: '0001'
+      },
+      field: {
+        kind: 'Select',
+        name: 'uu',
+        validate: () => {},
+        options: {},
+      },
+      record: {
+        recordID: '1000',
+        values: {
+          uu: ''
+        },
+      },
+      valueOnly: true,
+    }
+  })
+  const mountSelect = (opt) => shallowMount(Select, {
+    propsData,
+    ...opt,
+  })
+
+  it('determine field label for multi-value fields', () => {
+    const tests = [
+      {
+        name: 'valid entries',
+        options: [{ value: 'o1', text: 'l1' }],
+        value: 'o1',
+        expected: 'l1',
+      },
+      {
+        name: 'fallback to value',
+        options: [{ value: 'o1' }],
+        value: 'o1',
+        expected: 'o1',
+      },
+      {
+        name: 'fallback to value if option not found',
+        options: [],
+        value: 'o1',
+        expected: 'o1',
+      },
+    ]
+
+    // @todo improve this
+    for (const t of tests) {
+      propsData.field.options.options = t.options
+
+      const wrap = mountSelect()
+      expect(wrap.vm.findLabel(t.value), t.name).to.eq(t.expected)
+    }
+  })
+})

--- a/tests/unit/specs/lib/field/Select.spec.js
+++ b/tests/unit/specs/lib/field/Select.spec.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+/* ESLint didn't like some expects */
+
+import { expect } from 'chai'
+import { Select } from 'corteza-webapp-compose/src/lib/field/Select'
+
+describe('lib/field/Select.js', () => {
+  it('pre-process select options', () => {
+    const tests = [
+      {
+        name: 'handle legacy - text values',
+        options: ['opt1', 'opt2'],
+        expected: [{ value: 'opt1', text: 'opt1' }, { value: 'opt2', text: 'opt2' }],
+      },
+
+      {
+        name: 'handle valid values',
+        options: [{ value: 'opt1', text: 'opt1' }, { value: 'opt2', text: 'opt2' }],
+        expected: [{ value: 'opt1', text: 'opt1' }, { value: 'opt2', text: 'opt2' }],
+      },
+      {
+        name: 'handle case where text is not defined',
+        options: [{ value: 'opt1' }, { value: 'opt2' }],
+        expected: [{ value: 'opt1', text: 'opt1' }, { value: 'opt2', text: 'opt2' }],
+      },
+    ]
+
+    for (const t of tests) {
+      const s = new Select(t)
+      expect(s.options, t.name).to.deep.eq(t.expected)
+    }
+  })
+})

--- a/tests/unit/specs/lib/field/Viewer/select.spec.js
+++ b/tests/unit/specs/lib/field/Viewer/select.spec.js
@@ -1,0 +1,100 @@
+/* eslint-disable */
+import { expect } from 'chai'
+import Select from 'corteza-webapp-compose/src/lib/field/Viewer/Select'
+import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
+
+describe('lib/field/Viewer/Select.vue', () => {
+  let propsData
+  beforeEach(() => {
+    propsData = {
+      namespace: {
+        namespaceID: '0001'
+      },
+      field: {
+        kind: 'Select',
+        name: 'uu',
+        options: {}
+      },
+      record: {
+        recordID: '1000',
+        values: {
+          uu: ''
+        },
+      },
+      valueOnly: true,
+    }
+  })
+  const mountSelect = (opt) => shallowMount(Select, {
+    propsData,
+    ...opt,
+  })
+
+  it('determine field label (not multi-value)', () => {
+    const tests = [
+      {
+        name: 'valid entries',
+        options: [{ value: 'o1', text: 'l1' }],
+        values: { uu: 'o1' },
+        expected: function (wrap) {
+          const opt = wrap.find('div')
+          expect(opt.exists(), this.name).to.be.true
+          expect(opt.html(), this.name).to.include('l1')
+        },
+      },
+
+      {
+        name: 'fallback to value',
+        options: [{ value: 'o1' }],
+        values: { uu: 'o1' },
+        expected: function (wrap) {
+          const opt = wrap.find('div')
+          expect(opt.exists(), this.name).to.be.true
+          expect(opt.html(), this.name).to.include('o1')
+        },
+      },
+    ]
+
+    for (const t of tests) {
+      propsData.field.options.options = t.options
+      propsData.record.values = t.values
+      const wrap = mountSelect()
+      t.expected(wrap)
+    }
+  })
+
+  it('determine field label (multi-value)', () => {
+    const tests = [
+      {
+        name: 'valid entries',
+        options: [{ value: 'o1', text: 'l1' }, { value: 'o2', text: 'l2' }],
+        values: { uu: ['o1', 'o2'] },
+        expected: function (wrap) {
+          const opt = wrap.find('div')
+          expect(opt.exists(), this.name).to.be.true
+          expect(opt.html(), this.name).to.include('l1')
+          expect(opt.html(), this.name).to.include('l2')
+        },
+      },
+
+      {
+        name: 'fallback to value',
+        options: [{ value: 'o1' }, { value: 'o2' }],
+        values: { uu: ['o1', 'o2'] },
+        expected: function (wrap) {
+          const opt = wrap.find('div')
+          expect(opt.exists(), this.name).to.be.true
+          expect(opt.html(), this.name).to.include('o1')
+          expect(opt.html(), this.name).to.include('o2')
+        },
+      },
+    ]
+
+    for (const t of tests) {
+      propsData.field.options.options = t.options
+      propsData.record.values = t.values
+      propsData.field.isMulti = true
+      const wrap = mountSelect()
+      t.expected(wrap)
+    }
+  })
+})


### PR DESCRIPTION
A few extra tweaks:

Disable add button if nothing provided:
![Screenshot from 2019-10-24 19-09-00](https://user-images.githubusercontent.com/12545711/67508687-c22e0f00-f691-11e9-8bb2-76720e378021.png)

Add value + label
![Screenshot from 2019-10-24 19-07-06](https://user-images.githubusercontent.com/12545711/67508605-a0cd2300-f691-11e9-96b0-8b174a2d6574.png)

Prevent duplicate values/labels
*note: this only checks newly added, for backwards compatability*
![Screenshot from 2019-10-24 19-07-14](https://user-images.githubusercontent.com/12545711/67508607-a0cd2300-f691-11e9-87d7-79e429ca2def.png)

On record create/edit
![Screenshot from 2019-10-24 19-07-38](https://user-images.githubusercontent.com/12545711/67508608-a165b980-f691-11e9-9162-cd40e49fb010.png)

On record view
![Screenshot from 2019-10-24 19-07-43](https://user-images.githubusercontent.com/12545711/67508610-a165b980-f691-11e9-8def-4a74afc7283b.png)
