### PR TITLE
On record delete

### DIFF
--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -206,6 +206,7 @@ export default {
     record: {
       label: 'Record',
       deleteRecord: 'Delete record',
+      recordDeleted: 'This record was deleted',
       confirmDelete: 'Are you sure you want to delete this record?',
       preview: {
         fieldsFromModule: 'Single record block, displaying fields ({{0}}) from module {{1}}',

--- a/tests/unit/specs/views/Public/Pages/Records/view.spec.js
+++ b/tests/unit/specs/views/Public/Pages/Records/view.spec.js
@@ -1,0 +1,65 @@
+/* eslint-disable */
+/* ESLint didn't like some expects */
+
+import { expect } from 'chai'
+import { shallowMount } from 'corteza-webapp-compose/tests/lib/helpers'
+import View from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
+import Namespace from 'corteza-webapp-common/src/lib/types/compose/namespace'
+import Module from 'corteza-webapp-compose/src/lib/module'
+import Page from 'corteza-webapp-compose/src/lib/page'
+import sinon from 'sinon'
+import fp from 'flush-promises'
+
+describe('views/Public/Pages/Records/View.vue', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  let $ComposeAPI, propsData
+  beforeEach(() => {
+    $ComposeAPI = {}
+    propsData = {
+      namespace: new Namespace({ namespaceID: '000' }),
+      page: new Page({ pageID: '100', moduleID: '300' }),
+      recordID: '200',
+    }
+  })
+
+  const mountView = (opt) => shallowMount(View, {
+    mocks: { $ComposeAPI },
+    propsData,
+    ...opt,
+  })
+
+  const stubRecordLoad = () => {
+    sinon.stub(View.computed, 'module').returns(new Module({ moduleID: '300', fields: [{ name: 'f1', kind: 'String' }] }))
+    $ComposeAPI.recordRead = sinon.stub().resolves({ recordID: '200', values: { f1: 'v1' } })
+  }
+
+  describe('record load', () => {
+    it('load record on component load', async () => {
+      stubRecordLoad()
+      const wrap = mountView()
+      await fp()
+
+      expect(wrap.vm.record).to.not.be.undefined
+      expect(wrap.vm.record.recordID).to.eq('200')
+    })
+  })
+
+
+  describe('on delete', () => {
+    it('preserve view, show notification', async () => {
+      stubRecordLoad()
+      const wrap = mountView()
+      sinon.stub(wrap.vm, 'deleteRecord').resolves({})
+      await fp()
+
+      wrap.vm.handleDelete()
+      await fp()
+
+      expect(wrap.vm.record).to.not.be.undefined
+      expect(wrap.find('b-alert').exists()).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
On record delete, preserve the record in the state until the user leaves the page. Show notification that it was deleted; remove editing-related options.

Record present:
![Screenshot from 2019-10-25 10-00-20](https://user-images.githubusercontent.com/12545711/67555194-1c21e980-f711-11e9-9a13-95e53318db0f.png)

Record deleted:
*Note: notification is permanent, fixed to the top of the page*
![Screenshot from 2019-10-25 10-00-28](https://user-images.githubusercontent.com/12545711/67555195-1cba8000-f711-11e9-9f2d-dfd1fdf95cc9.png)

