### PR TITLE
Add tabs to block configurators

### DIFF
--- a/src/lib/block/BuilderEdit/basic.vue
+++ b/src/lib/block/BuilderEdit/basic.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <b-form-group for="title" :label="$t('block.general.titleLabel')">
+      <b-form-input
+        v-model="block.title"
+        type="text"
+        class="form-control form-control-sm"
+        id="title"
+        :placeholder="$t('block.general.titlePlaceholder')">
+      </b-form-input>
+    </b-form-group>
+    <b-form-group for="description" :label="$t('block.general.descriptionLabel')">
+      <b-form-input
+        v-model="block.description"
+        type="text"
+        class="form-control form-control-sm"
+        id="description"
+        :placeholder="$t('block.general.descriptionPlaceholder')">
+      </b-form-input>
+    </b-form-group>
+    <hr />
+    <div class="row">
+      <div class="col-sm-8">
+        <b-form-group for="color" :label="$t('block.general.headerStyle')">
+          <b-form-select id="color"
+                          v-model="block.style.variants.headerText"
+                          :options="textVariants"/>
+        </b-form-group>
+        <b-form-group>
+          <b-form-radio-group
+            v-model="block.style.variants.headerBg"
+            :options="bgVariants"
+          ></b-form-radio-group>
+          <b-form-checkbox
+            v-model="block.style.variants.border"
+            class="mt-2"
+            unchecked-value="0"
+            :value="borderStyle"
+          >{{ $t('block.general.border') }}</b-form-checkbox>
+        </b-form-group>
+        <b-form-group for="color" :label="$t('block.general.bodyStyle')">
+          <b-form-radio-group id="color"
+                              v-model="block.style.variants.bodyBg"
+                              :options="bgVariants"/>
+        </b-form-group>
+      </div>
+      <div class="col-sm-4 d-flex flex-column rounded-sm">
+          <label>{{ $t('block.general.preview') }}</label>
+          <p class="p-2 mb-0 border-bottom" :class="blockClass" >{{ block.title }}</p>
+          <small class="px-2">{{ block.description }}</small>
+          <div :class="'bg-'+block.style.variants.bodyBg" class=" p-2 flex-grow-1">
+            {{ $t('block.general.previewBody') }}
+          </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    block: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  data () {
+    return {
+      textVariants: [
+        { value: 'primary', text: this.$t('block.general.style.default') },
+        { value: 'secondary', text: this.$t('block.general.style.secondary') },
+        { value: 'white', text: this.$t('block.general.style.white') },
+        { value: 'light', text: this.$t('block.general.style.light') },
+        { value: 'dark', text: this.$t('block.general.style.dark') },
+        { value: 'success', text: this.$t('block.general.style.success') },
+        { value: 'warning', text: this.$t('block.general.style.warning') },
+        { value: 'danger', text: this.$t('block.general.style.danger') },
+      ],
+      bgVariants: [
+        { value: 'white', text: this.$t('block.general.style.whiteBg') },
+        { value: 'light', text: this.$t('block.general.style.lightBg') },
+        { value: 'dark', text: this.$t('block.general.style.darkBg') },
+      ],
+    }
+  },
+
+  computed: {
+    borderStyle () {
+      return this.block.style.variants.headerText
+    },
+
+    blockClass () {
+      return [
+        'text-' + this.block.style.variants.headerText,
+        'bg-' + this.block.style.variants.headerBg,
+        'border-' + this.block.style.variants.border,
+      ]
+    },
+  },
+
+  watch: {
+    'block.style.variants.headerText': {
+      handler (v) {
+        if (this.block.style.variants.border !== '0') {
+          this.block.style.variants.border = v
+        }
+      },
+    },
+  },
+}
+</script>

--- a/src/lib/block/BuilderEdit/basic.vue
+++ b/src/lib/block/BuilderEdit/basic.vue
@@ -65,9 +65,9 @@ export default {
     },
   },
 
-  data () {
-    return {
-      textVariants: [
+  computed: {
+    textVariants () {
+      return [
         { value: 'primary', text: this.$t('block.general.style.default') },
         { value: 'secondary', text: this.$t('block.general.style.secondary') },
         { value: 'white', text: this.$t('block.general.style.white') },
@@ -76,16 +76,17 @@ export default {
         { value: 'success', text: this.$t('block.general.style.success') },
         { value: 'warning', text: this.$t('block.general.style.warning') },
         { value: 'danger', text: this.$t('block.general.style.danger') },
-      ],
-      bgVariants: [
+      ]
+    },
+
+    bgVariants () {
+      return [
         { value: 'white', text: this.$t('block.general.style.whiteBg') },
         { value: 'light', text: this.$t('block.general.style.lightBg') },
         { value: 'dark', text: this.$t('block.general.style.darkBg') },
-      ],
-    }
-  },
+      ]
+    },
 
-  computed: {
     borderStyle () {
       return this.block.style.variants.headerText
     },

--- a/src/lib/block/BuilderEdit/index.vue
+++ b/src/lib/block/BuilderEdit/index.vue
@@ -1,72 +1,30 @@
 <template>
-  <div class="container">
-    <b-form-group for="title" :label="$t('block.general.titleLabel')">
-      <b-form-input
-        v-model="block.title"
-        type="text"
-        class="form-control form-control-sm"
-        id="title"
-        :placeholder="$t('block.general.titlePlaceholder')">
-      </b-form-input>
-    </b-form-group>
-    <b-form-group for="description" :label="$t('block.general.descriptionLabel')">
-      <b-form-input
-        v-model="block.description"
-        type="text"
-        class="form-control form-control-sm"
-        id="description"
-        :placeholder="$t('block.general.descriptionPlaceholder')">
-      </b-form-input>
-    </b-form-group>
-    <div class="row">
-      <div class="col-sm-8">
-        <b-form-group for="color" :label="$t('block.general.headerStyle')">
-          <b-form-select id="color"
-                         v-model="block.style.variants.headerText"
-                         :options="textVariants"/>
-        </b-form-group>
-        <b-form-group>
-          <b-form-radio-group
-            v-model="block.style.variants.headerBg"
-            :options="bgVariants"
-          ></b-form-radio-group>
-          <b-form-checkbox
-            v-model="block.style.variants.border"
-            class="mt-2"
-            unchecked-value="0"
-            :value="borderStyle"
-          >{{ $t('block.general.border') }}</b-form-checkbox>
-        </b-form-group>
-        <b-form-group for="color" :label="$t('block.general.bodyStyle')">
-          <b-form-radio-group id="color"
-                              v-model="block.style.variants.bodyBg"
-                              :options="bgVariants"/>
-        </b-form-group>
-      </div>
-      <div class="col-sm-4 d-flex flex-column rounded-sm">
-          <label>{{ $t('block.general.preview') }}</label>
-          <p class="p-2 mb-0 border-bottom" :class="blockClass" >{{ block.title }}</p>
-          <small class="px-2">{{ block.description }}</small>
-          <div :class="'bg-'+block.style.variants.bodyBg" class=" p-2 flex-grow-1">
-            {{ $t('block.general.previewBody') }}
-          </div>
-      </div>
-    </div>
-    <hr>
-    <component :is="block.kind"
-               :namespace="namespace"
-               :module="module"
-               :page="page"
-               :options.sync="block.options"/>
-  </div>
+  <b-tabs active-nav-item-class="bg-grey"
+          nav-wrapper-class="bg-white"
+          active-tab-class="tab-content h-auto overflow-auto"
+          card>
+
+    <b-tab active :title="$t('general.label.general')">
+      <basic :block="block" />
+    </b-tab>
+    <b-tab v-if="blockComponent" :title="block.kind">
+      <component :is="block.kind"
+                 :namespace="namespace"
+                 :module="module"
+                 :page="page"
+                 :options.sync="block.options"/>
+    </b-tab>
+  </b-tabs>
 </template>
 
 <script>
 import * as EditBlocks from './loader'
+import basic from './basic'
 
 export default {
   components: {
     ...EditBlocks,
+    basic,
   },
 
   props: {
@@ -91,48 +49,16 @@ export default {
     },
   },
 
-  data () {
-    return {
-      textVariants: [
-        { value: 'primary', text: this.$t('block.general.style.default') },
-        { value: 'secondary', text: this.$t('block.general.style.secondary') },
-        { value: 'white', text: this.$t('block.general.style.white') },
-        { value: 'light', text: this.$t('block.general.style.light') },
-        { value: 'dark', text: this.$t('block.general.style.dark') },
-        { value: 'success', text: this.$t('block.general.style.success') },
-        { value: 'warning', text: this.$t('block.general.style.warning') },
-        { value: 'danger', text: this.$t('block.general.style.danger') },
-      ],
-      bgVariants: [
-        { value: 'white', text: this.$t('block.general.style.whiteBg') },
-        { value: 'light', text: this.$t('block.general.style.lightBg') },
-        { value: 'dark', text: this.$t('block.general.style.darkBg') },
-      ],
-    }
-  },
-
   computed: {
-    borderStyle () {
-      return this.block.style.variants.headerText
-    },
-
-    blockClass () {
-      return [
-        'text-' + this.block.style.variants.headerText,
-        'bg-' + this.block.style.variants.headerBg,
-        'border-' + this.block.style.variants.border,
-      ]
-    },
-  },
-
-  watch: {
-    'block.style.variants.headerText': {
-      handler (v) {
-        if (this.block.style.variants.border !== '0') {
-          this.block.style.variants.border = v
-        }
-      },
+    blockComponent () {
+      // If block doesn't have a configurator, we show no block tab
+      return EditBlocks[this.block.kind]
     },
   },
 }
 </script>
+<style lang="scss" scoped>
+.tab-content {
+  max-height: 70vh;
+}
+</style>

--- a/src/lib/field/Configurator/index.vue
+++ b/src/lib/field/Configurator/index.vue
@@ -1,7 +1,7 @@
 <template>
   <b-tabs active-nav-item-class="bg-grey"
           nav-wrapper-class="bg-white"
-          active-tab-class="tab-content"
+          active-tab-class="tab-content h-auto overflow-auto"
           card>
 
     <b-tab active :title="$t('general.label.general')">
@@ -41,8 +41,6 @@ export default {
 
 <style lang="scss" scoped>
 .tab-content {
-  height: auto;
   max-height: 70vh;
-  overflow-y: auto;
 }
 </style>

--- a/src/views/Admin/Modules/Edit.vue
+++ b/src/views/Admin/Modules/Edit.vue
@@ -76,7 +76,7 @@
       @hide="updateField=null"
       :visible="!!updateField"
       body-class="p-0 border-top-0"
-      header-class="px-3 pt-3 pb-0 border-bottom-0">
+      header-class="p-3 pb-0 border-bottom-0">
       <field-configurator :field.sync="updateField" />
     </b-modal>
     <editor-toolbar :back-link="{name: 'admin.modules'}"

--- a/src/views/Admin/Pages/Builder.vue
+++ b/src/views/Admin/Pages/Builder.vue
@@ -26,7 +26,9 @@
         size="lg"
         @ok="updateBlocks"
         @hide="editor=null"
-        :visible="showCreator">
+        :visible="showCreator"
+        body-class="p-0 border-top-0"
+        header-class="p-3 pb-0 border-bottom-0">
         <block-edit v-if="showCreator"
                     :namespace="namespace"
                     :module="module"
@@ -39,11 +41,12 @@
         :ok-title="$t('general.label.saveAndClose')"
         ok-variant="dark"
         ok-only
-        centered
         size="lg"
         @ok="updateBlocks"
         @hide="editor=null"
-        :visible="showEditor">
+        :visible="showEditor"
+        body-class="p-0 border-top-0"
+        header-class="p-3 pb-0 border-bottom-0">
         <block-edit v-if="showEditor"
                     :namespace="namespace"
                     :module="module"


### PR DESCRIPTION
Added tabs to block configurators. General tab and block kind tab. 
![Screenshot from 2019-10-25 12-09-57](https://user-images.githubusercontent.com/15791641/67564320-00274380-f723-11e9-9c7c-393f6110c85b.png)
