### PR TITLE
Add record cloning

### DIFF
--- a/src/components/faIcons.js
+++ b/src/components/faIcons.js
@@ -48,6 +48,7 @@ import {
   faBell,
   faClock,
   faSquare,
+  faClone,
 } from '@fortawesome/free-regular-svg-icons'
 
 library.add(
@@ -96,4 +97,5 @@ library.add(
   faRemoveFormat,
   faTasks,
   faParagraph,
+  faClone,
 )

--- a/src/lib/block/View/RecordList.vue
+++ b/src/lib/block/View/RecordList.vue
@@ -52,11 +52,15 @@
               <field-viewer v-else-if="col.canReadRecordValue" :field="col" value-only :record="row" :namespace="namespace"/>
               <i v-else class="text-secondary">{{ $t('field.noPermission') }}</i>
             </td>
-            <td class="text-right text-nowrap">
+            <td class="text-right text-nowrap d-flex justify-content-center">
               <b-button variant="link"
+                        class="p-0 m-0 pr-3"
                         @click.prevent="createReminder(row)">
                 <font-awesome-icon :icon="['far', 'bell']" />
               </b-button>
+              <router-link v-if="recordListModule.canCreateRecord" class="pr-3" :to="{ name: 'page.record.create', params: { pageID: options.pageID, values: row.values }, query: null }">
+                <font-awesome-icon :icon="['far', 'clone']"></font-awesome-icon>
+              </router-link>
               <router-link v-if="recordListModule.canUpdateRecord" :to="{ name: 'page.record.edit', params: { pageID: options.pageID, recordID: row.recordID }, query: null }">
                 <font-awesome-icon :icon="['far', 'edit']"></font-awesome-icon>
               </router-link>

--- a/tests/unit/specs/views/Public/Pages/Records/Create.spec.js
+++ b/tests/unit/specs/views/Public/Pages/Records/Create.spec.js
@@ -14,13 +14,14 @@ const localVue = createLocalVue()
 localVue.use(Vuex)
 
 describe('Create', () => {
+  let propsData, namespace, refRecModule, refRecord, store
 
-  it('properly links passed record reference', () => {
-    const namespace = new Namespace({namespaceID: '3003'})
-    const refRecModule = new Module({moduleID: '2002', fields: [ { name: 'dummy' } ]})
-    const refRecord = new Record(refRecModule, { recordID: '1000' })
+  namespace = new Namespace({namespaceID: '3003'})
+  refRecModule = new Module({moduleID: '2002', fields: [ { name: 'dummy' } ]})
+  refRecord = new Record(refRecModule, { recordID: '1000' })
 
-    const store = new Vuex.Store({ modules: { module: {
+  beforeEach(() => {
+    store = new Vuex.Store({ modules: { module: {
       namespaced: true,
       state: {},
       getters: {
@@ -35,18 +36,32 @@ describe('Create', () => {
       }
     }}})
 
-    const cmp = shallowMount(Create, {
-      store,
-      localVue,
-      propsData: {
-        namespace,
-        refRecord,
-        page: new Page({ moduleID: "2001"})
-      }
-    })
+    propsData = {
+      namespace,
+      refRecord,
+      page: new Page({ moduleID: "2001"})
+    }
+  })
+
+  const mountCreate = (opt) => shallowMount(Create, {
+    store,
+    localVue,
+    propsData,
+    ...opt,
+  })
+
+  it('properly links passed record reference', () => {
+    const cmp = mountCreate()
 
     expect(cmp.vm.record).not.to.be.an('undefined')
     expect(cmp.vm.record.values.ref).not.to.be.an('undefined')
     expect(cmp.vm.record.values.ref).to.equal(refRecord.recordID)
+  })
+
+  it('properly prefills record values', () => {
+    propsData.values = { Name:'Test' }
+    const cmp = mountCreate()
+
+    expect(cmp.vm.record.values).to.have.property('Name').that.deep.equals('Test')
   })
 })


### PR DESCRIPTION
Adds ability to clone records.
![Screenshot from 2020-01-03 17-05-52](https://user-images.githubusercontent.com/15791641/71734071-544d5300-2e4b-11ea-9300-c8bfd1ec1c4e.png)


When button is clicked. You are redirected to create record page with prefilled values.
![Screenshot from 2020-01-03 17-07-06](https://user-images.githubusercontent.com/15791641/71734140-7e067a00-2e4b-11ea-9ee8-4934966a4858.png)


Record isn't created until 'Save' button is clicked.