### PR TITLE
Feature record browser

### DIFF
--- a/src/components/Common/RecordToolbar.vue
+++ b/src/components/Common/RecordToolbar.vue
@@ -1,0 +1,100 @@
+<template>
+  <b-container
+    fluid
+    class="bg-white shadow border-top py-3 px-3 m-0"
+  >
+    <b-row
+      no-gutters
+    >
+      <b-col cols="4">
+        <b-button
+          variant="link"
+          @click.prevent="$emit('back')"
+        >
+          &#171; {{ $t('general.label.back') }}
+        </b-button>
+      </b-col>
+      <b-col
+        cols="4"
+        class="text-center"
+      >
+        <b-button
+          v-if="module.canCreateRecord"
+          variant="outline-secondary"
+          class="m-1"
+          @click.prevent="$emit('clone')"
+        >
+          {{ $t('general.label.clone') }}
+        </b-button>
+
+        <b-button
+          v-if="module.canCreateRecord"
+          variant="outline-secondary"
+          class="m-1"
+          @click.prevent="$emit('add')"
+        >
+          {{ $t('general.label.addNew') }}
+        </b-button>
+      </b-col>
+      <b-col
+        cols="4"
+        class="text-right"
+      >
+        <c-input-confirm
+          :disabled="!module.canDeleteRecord || isDeleted"
+          @confirmed="$emit('delete')"
+          class="m-1"
+        >
+          {{ $t('general.label.delete') }}
+        </c-input-confirm>
+
+        <b-button
+          v-if="module.canUpdateRecord && !isDeleted && !inEditing"
+          variant="outline-secondary"
+          class="m-1"
+          @click.prevent="$emit('edit')"
+        >
+          {{ $t('general.label.edit') }}
+        </b-button>
+
+        <b-button
+          v-else-if="module.canUpdateRecord"
+          :disabled="!isValid || isDeleted"
+          class="m-1"
+          variant="primary"
+          @click.prevent="$emit('submit')"
+        >
+          {{ $t('general.label.save') }}
+        </b-button>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script>
+import { compose } from '@cortezaproject/corteza-js'
+
+export default {
+  props: {
+    module: {
+      type: compose.Module,
+      required: false,
+    },
+
+    isValid: {
+      type: Boolean,
+      required: true,
+    },
+
+    inEditing: {
+      type: Boolean,
+      required: true,
+    },
+
+    isDeleted: {
+      type: Boolean,
+      default: true,
+    },
+  },
+}
+</script>

--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -182,8 +182,24 @@ export default {
       hideRecordCloneButton: 'Hide clone record button',
       hideRecordEditButton: 'Hide edit record button',
       hideRecordViewButton: 'Hide view record button',
-
       cancelSelection: 'cancel',
+
+      filter: {
+        title: 'Record list filter',
+        update: 'Update filter',
+        label: 'Filter',
+        addField: 'Add new filter field',
+        field: 'Filter field',
+        fieldPlaceholder: 'Pick a field',
+        fieldValue: 'Field value',
+        fieldValuePlaceholder: 'Input field filter',
+        deletedRecords: 'Deleted records',
+        without: 'Without',
+        including: 'Including',
+        only: 'Only',
+        byValue: 'Filter records based on field value',
+        note: 'Note: If Field value is undefined, the filter will look for records where that field value is undefined.',
+      },
       record: {
         newLabel: 'New records',
         hideAddButton: 'Hide add record button',

--- a/src/lib/record-filter.js
+++ b/src/lib/record-filter.js
@@ -1,0 +1,69 @@
+// Helper to determine if and value for given bool query
+// == is intentional
+const toBoolean = (v) => {
+  /* eslint-disable eqeqeq */
+  if (v == 'false' || v == 0) {
+    return false
+  }
+  if (v == 'true' || v == 1) {
+    return true
+  }
+
+  return undefined
+}
+
+// Helper function that creates a query for a specific field kind
+export function getFieldFilter (field, query) {
+  const boolQuery = toBoolean(query)
+  const numQuery = Number.parseFloat(query)
+
+  // To SQLish LIKE param
+  const strQuery = query
+    // replace * with %
+    .replace(/[*%]+/g, '%')
+    // Remove all trailing * and %
+    .replace(/[%]+$/, '')
+    // Remove all leading * and %
+    .replace(/^[%]+/, '')
+
+  if (field.kind === 'Number' && !isNaN(numQuery)) {
+    return `${field.name} = ${numQuery}`
+  }
+
+  // Boolean should search for literal values. Example `${field.name} = true` or just `${field.name}
+  // At the moment it doesn't seem to be working as intended
+  if (field.kind === 'Bool' && boolQuery !== undefined) {
+    if (boolQuery) {
+      return `${field.name} = true`
+    } else {
+      return `${field.name} = false OR ${field.name} IS NULL`
+    }
+  }
+
+  if (['String', 'DateTime', 'Select', 'Url', 'Email'].includes(field.kind)) {
+    return `${field.name} LIKE '%${strQuery}%'`
+  }
+}
+
+// Takes fields and prefilter and merges it query expression over all columns we're showing
+// ie: Return records that have strings in columns (fields) we're showing that start with <query> in case
+//     of text or are exactly the same in case of numbers
+export function queryToFilter (query = '', prefilter = '', fields = []) {
+  query = (query || '').trim()
+
+  if (!query) {
+    return prefilter || ''
+  }
+
+  // When searching, always reset filter with prefilter + query
+  query = fields
+    .map(qf => getFieldFilter(qf, query))
+    .filter(q => !!q)
+    .join(' OR ')
+
+  if (prefilter) {
+    return `(${prefilter}) AND (${query})`
+  }
+
+  return query
+}

--- a/src/mixins/record.js
+++ b/src/mixins/record.js
@@ -1,0 +1,178 @@
+// This mixin is used on View component of Records.
+
+import { compose, validator, NoID } from '@cortezaproject/corteza-js'
+import { mapGetters } from 'vuex'
+
+export default {
+  data () {
+    return {
+      inEditing: false,
+      record: null,
+      errors: new validator.Validated(),
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+    }),
+
+    validator () {
+      if (!this.module) {
+        throw new Error('can not initialize record validator without module')
+      }
+
+      return new compose.RecordValidator(this.module)
+    },
+
+    isValid () {
+      return this.errors.valid()
+    },
+
+    /**
+     * Tells if given record is deleted; If record not provided, returns undefined
+     * @returns {Boolean|undefined}
+     */
+    isDeleted () {
+      if (!this.record) {
+        return
+      }
+      return !!this.record.deletedAt
+    },
+  },
+
+  watch: {
+    'record.values': {
+      deep: true,
+      handler () {
+        if (!this.errors.valid()) {
+          this.errors = this.validator.run(this.record)
+        }
+      },
+    },
+  },
+
+  methods: {
+    /**
+     * Handle form submit for record create & update
+     *
+     *  -> dispatch beforeFormSubmit (on ui:compose:record-page)
+     *  -> validate record (see validateRecord())
+     *     -> stop on errors
+     *  -> send record to the API
+     *  -> apply changes received from the API to current record
+     *  -> dispatch afterFormSubmit
+     *  -> redirect user to record viewer page
+     *
+     * @returns {Promise<void>}
+     */
+    handleFormSubmit (route = 'page.record') {
+      const isNew = this.record.recordID === NoID
+
+      return this
+        .dispatchUiEvent('beforeFormSubmit')
+        .then(() => this.validateRecord())
+        .then(() => {
+          if (isNew) {
+            return this.$ComposeAPI.recordCreate(this.record)
+          } else {
+            return this.$ComposeAPI.recordUpdate(this.record)
+          }
+        })
+        .catch(err => {
+          const { details = undefined } = err
+          if (!!details && Array.isArray(details) && details.length > 0) {
+            this.errors.push(...details)
+            throw new Error(this.$t('notification.record.validationErrors'))
+          }
+
+          throw err
+        })
+        .then((record) => this.record.apply(record))
+        .then(() => this.dispatchUiEvent('afterFormSubmit'))
+        .then(() => {
+          this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
+        })
+        .catch(this.defaultErrorHandler(this.$t(
+          isNew
+            ? 'notification.record.createFailed'
+            : 'notification.record.updateFailed',
+        )))
+    },
+
+    /**
+     * On delete, preserve user's view. Show a notification that the record
+     * has been deleted.
+     */
+    handleDelete () {
+      return this
+        .dispatchUiEvent('beforeDelete')
+        .then(() => this.$ComposeAPI.recordDelete(this.record))
+        .then(() => {
+          this.record.deletedAt = (new Date()).toISOString()
+        })
+        .then(() => this.dispatchUiEvent('afterDelete'))
+        .catch(this.defaultErrorHandler(this.$t('notification.record.deleteFailed')))
+    },
+
+    /**
+     * Validates record and dispatches onFormSubmitError
+     *
+     * onFormSubmitError is dispatched only if there are record errors,
+     * if not, we continue with form submit handling
+     *
+     * After onFormSubmitError, record is re-validated and if errors
+     * are still present, we stop form submit handing
+     *
+     * @returns {Promise<void>}
+     */
+    async validateRecord () {
+      this.errors = this.validator.run(this.record)
+      if (this.errors.valid()) {
+        return
+      }
+
+      await this.dispatchUiEvent('onFormSubmitError')
+
+      this.errors = this.validator.run(this.record)
+      if (!this.errors.valid()) {
+        throw new Error(this.$t('notification.record.validationErrors'))
+      }
+    },
+
+    /**
+     * Returns errors, filtered for a specific field
+     * @param name
+     * @returns {validator.Validated} filtered validation results
+     */
+    fieldErrors (name) {
+      if (!this.errors) {
+        return new validator.Validated()
+      }
+
+      return this.errors.filterByMeta('field', name)
+    },
+
+    /**
+     * Generic event dispatcher for ui:compose:record-page resource type
+     *
+     * This is used when deleting, updating, creating
+     * records and where validation errors occur
+     *
+     * @param eventType
+     */
+    dispatchUiEvent (eventType) {
+      const resourceType = `ui:compose:${this.getUiEventResourceType || 'record-page'}`
+
+      const args = {
+        errors: this.errors,
+        validator: this.validator,
+      }
+
+      return this
+        .$EventBus
+        .Dispatch(compose.RecordEvent(
+          this.record, { eventType, resourceType, args }))
+    },
+  },
+}

--- a/src/plugins/eventbus-pairs.js
+++ b/src/plugins/eventbus-pairs.js
@@ -2,6 +2,14 @@ const stdEventTypes = [
   'onManual',
 ]
 
+const recordPageEventTypes = [
+  'beforeFormSubmit',
+  'onFormSubmitError',
+  'afterFormSubmit',
+  'beforeDelete',
+  'afterDelete',
+]
+
 export default {
   compose: [
     ...stdEventTypes,
@@ -17,11 +25,11 @@ export default {
   ],
   'ui:compose:record-page': [
     ...stdEventTypes,
-    'beforeFormSubmit',
-    'onFormSubmitError',
-    'afterFormSubmit',
-    'beforeDelete',
-    'afterDelete',
+    ...recordPageEventTypes,
+  ],
+  'ui:compose:admin-record-page': [
+    ...stdEventTypes,
+    ...recordPageEventTypes,
   ],
   'ui:compose': [
     ...stdEventTypes,

--- a/src/views/Admin/Modules/Index.vue
+++ b/src/views/Admin/Modules/Index.vue
@@ -50,9 +50,17 @@
               </template>
               <template v-slot:cell(actions)="{ item: m }">
                 <b-button
-                   @click="openPageBuilder(m)"
-                   variant="link"
-                   class="mr-2 pt-0 text-dark">{{ $t('general.label.pageBuilder') }}</b-button>
+                  @click="openPageBuilder(m)"
+                  variant="link"
+                  class="mr-2 pt-0 text-dark"
+                >
+                  {{ $t('general.label.pageBuilder') }}
+                </b-button>
+                <span v-if="m.canReadRecord">
+                  <router-link :to="{name: 'admin.modules.record.list', params: { moduleID: m.moduleID }}" class="mr-2 text-dark">
+                    <font-awesome-icon :icon="['fas', 'bars']"></font-awesome-icon>
+                  </router-link>
+                </span>
                 <span v-if="m.canUpdateModule || m.canDeleteModule">
                   <router-link :to="{name: 'admin.modules.edit', params: { moduleID: m.moduleID }}" class="mr-2 text-dark">
                     <font-awesome-icon :icon="['far', 'edit']"></font-awesome-icon>

--- a/src/views/Admin/Modules/Records/Create.vue
+++ b/src/views/Admin/Modules/Records/Create.vue
@@ -1,0 +1,29 @@
+<script>
+import ViewRecord from './View'
+import { compose } from '@cortezaproject/corteza-js'
+
+export default {
+  name: 'CreateRecord',
+
+  extends: ViewRecord,
+
+  props: {
+    // If component was called (via router) with some pre-seed values
+    values: {
+      type: Object,
+      required: false,
+      default: () => ({}),
+    },
+  },
+
+  data () {
+    return {
+      inEditing: true,
+    }
+  },
+
+  created () {
+    this.record = new compose.Record(this.module, { values: this.values })
+  },
+}
+</script>

--- a/src/views/Admin/Modules/Records/Edit.vue
+++ b/src/views/Admin/Modules/Records/Edit.vue
@@ -1,0 +1,21 @@
+<script>
+import ViewRecord from './View'
+
+export default {
+  name: 'EditRecord',
+
+  extends: ViewRecord,
+
+  data () {
+    return {
+      inEditing: true,
+    }
+  },
+
+  methods: {
+    handleBack () {
+      this.$router.push({ name: 'admin.modules.record.view' })
+    },
+  },
+}
+</script>

--- a/src/views/Admin/Modules/Records/List.vue
+++ b/src/views/Admin/Modules/Records/List.vue
@@ -1,0 +1,697 @@
+<template>
+  <div class="h-100 p-2">
+    <b-card
+      no-body
+      class="h-100 border-0 shadow-sm rounded-lg"
+      :header="title"
+      header-class="sticky-top h5 pl-2"
+      header-bg-variant="white"
+      header-text-variant="primary"
+      header-border-variant="primary"
+    >
+      <div
+        class="p-0 m-0"
+      >
+        <b-container
+          ref="header"
+          class="m-0 p-2"
+          fluid
+        >
+          <b-row
+            no-gutters
+            class="m-0 p-0"
+          >
+            <b-col
+              cols="6"
+            >
+              <template v-if="module.canCreateRecord">
+                <router-link
+                  class="btn btn-sm btn-outline-primary float-left"
+                  :to="{
+                    name: 'admin.modules.record.create',
+                    params: { moduleID: module.moduleID },
+                    query: null,
+                  }"
+                >
+                  + {{ $t('block.recordList.addRecord') }}
+                </router-link>
+                <importer-modal
+                  :module="module"
+                  :namespace="namespace"
+                  class="ml-1 float-left"
+                />
+              </template>
+              <exporter-modal
+                :module="module"
+                :record-count="pagingStats.count"
+                :query="query"
+                :selection="selected"
+                @export="onExport"
+                class="ml-1 float-left"
+              />
+            </b-col>
+            <b-col
+              cols="6"
+            >
+              <b-input
+                v-model="query"
+                class="float-right mw-100"
+                size="sm"
+                type="search"
+                style="width: 200px;"
+                :placeholder="$t('general.label.search')" />
+
+              <b-button
+                variant="outline-primary"
+                size="sm"
+                class="float-right mr-1"
+                @click="openFilterModal"
+              >
+                {{ $t('block.recordList.filter.label') }}
+              </b-button>
+            </b-col>
+          </b-row>
+          <b-row
+            v-show="selected.length > 0"
+            class="text-light bg-secondary p-2 mt-2"
+          >
+            <b-col
+              cols="4"
+              class="pt-1 text-nowrap"
+            >
+              {{ $t('block.recordList.selected', { count: selected.length, total: filter.count }) }}
+              <a
+                class="text-light"
+                href="#"
+                @click.prevent="handleSelectAllOnPage({ isChecked: false })"
+              >
+                ({{ $t('block.recordList.cancelSelection') }})
+              </a>
+            </b-col>
+            <b-col
+              class="text-right"
+              cols="8"
+            >
+              <c-input-confirm
+                @confirmed="handleDeleteSelectedRecords()"
+                variant="link-light"
+              />
+            </b-col>
+          </b-row>
+        </b-container>
+      </div>
+      <b-card-body
+        class="p-0"
+      >
+        <b-table
+          hover
+          ref="table"
+          :responsive="true"
+          :sticky-header="true"
+          :show-empty="true"
+          :small="false"
+          selectable
+          select-mode="multi"
+          class="mh-100 m-0 mb-2 border-top"
+          :items="records"
+          :fields="fields"
+          no-sort-reset
+          @sort-changed="handleSort"
+          @row-selected="handleRowSelected"
+          @row-clicked="handleRowClicked"
+        >
+          <template #head()="{ field }">
+            {{ field.label }}
+          </template>
+          <template #cell()="{ item: r, field }">
+            <field-viewer
+              v-if="true"
+              :field="field.moduleField"
+              value-only
+              :record="r"
+              :module="module"
+              :namespace="namespace"
+            />
+            <i
+              v-else
+              class="text-secondary"
+            >
+              {{ $t('field.noPermission') }}
+            </i>
+          </template>
+          <template #cell(actions)="{ item: r }">
+            <div class="text-right">
+              <b-button
+                v-if="module.canCreateRecord"
+                variant="link"
+                class="p-0 m-0 pl-1 text-secondary"
+                :to="{ name: 'admin.modules.record.create', params: { moduleID: module.moduleID, values: r.values }}"
+              >
+                <font-awesome-icon
+                  :icon="['far', 'clone']"
+                />
+              </b-button>
+              <b-button
+                v-if="module.canUpdateRecord"
+                variant="link"
+                class="p-0 m-0 pl-1 text-secondary"
+                :to="{ name: 'admin.modules.record.edit', params: { moduleID: module.moduleID, recordID: r.recordID }, query: null }"
+              >
+                <font-awesome-icon
+                  :icon="['far', 'edit']"
+                />
+              </b-button>
+              <b-button
+                variant="link"
+                class="p-0 m-0 pl-1 text-secondary"
+                @click.prevent="handleRowClicked(r)"
+              >
+                <font-awesome-icon
+                  :icon="['far', 'eye']"
+                />
+              </b-button>
+            </div>
+          </template>
+          <template #head(selectable)>
+            <b-checkbox
+              :disabled="pagingStats.count === 0"
+              :checked="areAllRowsSelected"
+              @change="handleSelectAllOnPage({ isChecked: $event })"
+            />
+          </template>
+          <template #cell(selectable)="{ item, index, rowSelected }">
+            <b-checkbox
+              :checked="rowSelected"
+              @change="handleRowSelectCheckbox({ record: item, index, isChecked: $event })"
+            />
+          </template>
+          <template #table-busy>
+            <div class="text-center m-5">
+              <div>
+                <b-spinner
+                  small
+                  class="align-middle m-2"
+                />
+              </div>
+            </div>
+          </template>
+        </b-table>
+      </b-card-body>
+      <b-card-footer
+        class="p-0"
+      >
+        <b-container
+          ref="footer"
+          fluid
+          class="m-0 p-2"
+        >
+          <b-row
+            no-gutters
+          >
+            <b-col
+              class="pt-1 text-nowrap text-truncate"
+              cols="8"
+            >
+              <span
+                v-if="filter.count > filter.perPage"
+              >
+                {{ $t('block.recordList.pagination', pagingStats) }}
+              </span>
+              <span
+                v-else
+              >
+                {{ $t('block.recordList.paginationSingle', pagingStats) }}
+              </span>
+            </b-col>
+            <b-col
+              cols="4"
+            >
+              <b-pagination
+                v-if="filter.count > filter.perPage"
+                align="right"
+                aria-controls="record-list"
+                class="m-0"
+                size="sm"
+                v-model="filter.page"
+                :per-page="filter.perPage"
+                :total-rows="filter.count"
+              />
+            </b-col>
+          </b-row>
+        </b-container>
+      </b-card-footer>
+    </b-card>
+    <b-modal
+      v-model="filterFields.showModal"
+      id="filterModal"
+      :title="$t('block.recordList.filter.title')"
+      size="xl"
+      ok-only
+      :ok-title="$t('block.recordList.filter.update')"
+      @ok="refresh()"
+    >
+      <b-container class="p-0">
+        <b-form-group
+          :label="$t('block.recordList.filter.deletedRecords')"
+        >
+          <b-form-radio-group
+            v-model="filter.deleted"
+            :options="[
+              { value: 0, text: $t('block.recordList.filter.without') || 'excluded' },
+              { value: 1, text: $t('block.recordList.filter.including') || 'inclusive' },
+              { value: 2, text: $t('block.recordList.filter.only') || 'exclusive' }
+            ]"
+            buttons
+            button-variant="outline-secondary"
+            size="sm"
+            name="radio-btn-outline"
+          />
+        </b-form-group>
+        <hr>
+        <p>
+          <b>
+            {{ $t('block.recordList.filter.byValue') }}
+          </b>
+          <br>
+          <i
+            class="text-muted"
+          >
+            {{ $t('block.recordList.filter.note') }}
+          </i>
+        </p>
+        <div
+          v-for="(field, index) in filterFields.items"
+          :key="`${field.name}${index}`"
+        >
+          <b-row>
+            <b-col cols="6">
+              <b-form-group
+                :label="$t('block.recordList.filter.field')"
+              >
+                <vue-select
+                  v-model="field.name"
+                  :options="allModuleFields"
+                  :reduce="field => field.name"
+                  :disabled="!module"
+                  :placeholder="$t('block.recordList.filter.fieldPlaceholder')"
+                  option-text="label"
+                  @input="updateFilterField(index, $event)"
+                />
+              </b-form-group>
+            </b-col>
+            <b-col
+              cols="6"
+              class="pl-0 pr-2"
+              :class="{'pr-4': index === 0 }"
+            >
+              <b-form-group
+                :label="$t('block.recordList.filter.fieldValue')"
+              >
+                <b-input-group>
+                  <b-form-input
+                    v-model="field.value"
+                    :placeholder="$t('block.recordList.filter.fieldValuePlaceholder')"
+                  />
+                  <b-input-group-append
+                    v-if="index > 0"
+                  >
+                    <font-awesome-icon
+                      :icon="['fas', 'times']"
+                      @click="removeFilterField(index)"
+                      class="pointer text-secondary my-auto ml-2"
+                    />
+                  </b-input-group-append>
+                </b-input-group>
+              </b-form-group>
+            </b-col>
+          </b-row>
+          <hr class="mt-0">
+        </div>
+        <b-button
+          variant="outline-primary"
+          size="sm"
+          @click="addFilterField()"
+        >
+          + {{ $t('block.recordList.filter.addField') }}
+        </b-button>
+      </b-container>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+/*
+  NOTE !
+  This component duplicates the RecordListBase page block template and it's logic.
+  Since the RecordListBase component is meant to be used in the Public Grid as a Block
+  and this component is used in the Admin section and is not meant to be in a Grid.
+  A "Render" only component cannot replace both since the Public component needs to use slots.
+*/
+import { throttle } from 'lodash'
+import { mapGetters } from 'vuex'
+import { VueSelect } from 'vue-select'
+import FieldViewer from 'corteza-webapp-compose/src/components/ModuleFields/Viewer'
+import ExporterModal from 'corteza-webapp-compose/src/components/Public/Record/Exporter'
+import ImporterModal from 'corteza-webapp-compose/src/components/Public/Record/Importer'
+import { compose } from '@cortezaproject/corteza-js'
+import users from 'corteza-webapp-compose/src/mixins/users'
+import { getFieldFilter, queryToFilter } from 'corteza-webapp-compose/src/lib/record-filter'
+import { url } from '@cortezaproject/corteza-vue'
+
+export default {
+  components: {
+    FieldViewer,
+    ExporterModal,
+    ImporterModal,
+    VueSelect,
+  },
+
+  mixins: [
+    users,
+  ],
+
+  data () {
+    return {
+      query: null,
+
+      filterFields: {
+        showModal: false,
+        items: [
+          {
+            name: '',
+            value: '',
+            kind: '',
+          },
+        ],
+      },
+
+      filter: {
+        deleted: 0,
+        filter: '',
+        sort: 'createdAt DESC',
+        page: 1,
+        perPage: 20,
+        count: 0,
+      },
+
+      selected: [],
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+    }),
+
+    title () {
+      if (this.module) {
+        return `All records for module "${this.module.name}"`
+      } else {
+        return 'All module records'
+      }
+    },
+
+    areAllRowsSelected () {
+      const { count, perPage } = this.filter
+      return this.selected.length === (count < perPage ? count : perPage)
+    },
+
+    pagingStats () {
+      const { page, perPage, count } = this.filter
+      let pages = Math.ceil(count / perPage)
+      if (pages < 1) { pages = 1 }
+
+      return {
+        from: ((page - 1) * perPage) + 1,
+        to: (page * perPage),
+        page,
+        count,
+        pages,
+      }
+    },
+
+    module () {
+      if (this.$attrs.moduleID) {
+        return this.getModuleByID(this.$attrs.moduleID)
+      } else {
+        return undefined
+      }
+    },
+
+    namespace () {
+      return this.$attrs.namespace
+    },
+
+    allModuleFields () {
+      if (this.module) {
+        return this.module.fields
+          .filter(f => !['User', 'Record'].includes(f.kind))
+          .map(f => {
+            return {
+              label: f.label,
+              name: f.name,
+              kind: f.kind,
+            }
+          })
+      } else {
+        return []
+      }
+    },
+
+    fields () {
+      let fields = []
+      if (this.module) {
+        const pre = []
+        const post = []
+
+        // Use first five fields from the module.
+        fields = this.module.fields.slice(0, 5)
+
+        pre.push({ key: 'selectable', label: '', tdClass: 'selector', thClass: 'selector' })
+
+        const configured = fields.map(mf => ({
+          key: mf.name,
+          label: mf.label || mf.name,
+          moduleField: mf,
+          sortable: true,
+          tdClass: 'record-value',
+        }))
+
+        post.push({ key: 'actions', label: '', tdClass: 'actions' })
+
+        return [
+          ...pre,
+          ...configured,
+          ...post,
+        ]
+      }
+      return fields
+    },
+  },
+
+  watch: {
+    'filter.page' () {
+      this.refresh()
+    },
+
+    query: throttle(function (e) {
+      this.filter.query = queryToFilter(this.query, '', this.module.filterFields(this.module.fields.slice(0, 5)))
+      this.refresh()
+    }, 500),
+  },
+
+  methods: {
+    openFilterModal () {
+      this.filterFields.showModal = true
+    },
+
+    updateFilterField (index, name) {
+      // Field must be found because of vue-select limitations
+      const field = this.allModuleFields.find(f => f.name === name)
+      if (field) {
+        const { name, kind } = field
+        this.filterFields.items[index].name = name
+        this.filterFields.items[index].kind = kind
+      } else {
+        this.filterFields.items[index].name = ''
+        this.filterFields.items[index].kind = ''
+      }
+    },
+
+    updateFilterFieldValue (index, value) {
+      this.filterFields.items[index].value = value
+    },
+
+    addFilterField () {
+      this.filterFields.items.push({ name: '', value: '', kind: '' })
+    },
+
+    removeFilterField (index) {
+      if (index > -1) {
+        this.filterFields.items.splice(index, 1)
+      }
+    },
+
+    onExport (e) {
+      const { namespaceID, moduleID } = this.filter || {}
+      const { filterRaw } = e
+      e = {
+        ...e,
+        namespaceID,
+        moduleID,
+        filename: `${this.namespace.slug} - ${this.module.name}`,
+      }
+
+      if (filterRaw.rangeType === 'range') {
+        e.filename += ` - ${filterRaw.date.start} - ${filterRaw.date.end}`
+      } else {
+        e.filename += ` - ${filterRaw.rangeType}`
+      }
+
+      if (filterRaw.includeQuery) {
+        const queryF = queryToFilter(filterRaw.query, '', this.module.filterFields(this.module.fields.slice(0, 5)))
+        if (e.filters) {
+          e.filters = `(${e.filters}) AND `
+        } else {
+          e.filters = ''
+        }
+        if (queryF) {
+          e.filters += encodeURI(`(${queryF})`)
+        }
+      }
+
+      window.open(url.Make({
+        url: `${this.$ComposeAPI.baseURL}${this.$ComposeAPI.recordExportEndpoint(e)}`,
+        query: {
+          fields: e.fields,
+          filter: e.filters,
+          jwt: this.$auth.JWT,
+        },
+      }))
+    },
+
+    handleRowClicked ({ recordID }) {
+      this.$router.push({
+        name: 'admin.modules.record.view',
+        params: {
+          moduleID: this.module.moduleID,
+          recordID,
+        },
+        query: null,
+      })
+    },
+
+    handleSort ({ sortBy, sortDesc = false }) {
+      this.filter.sort = `${sortBy} ${sortDesc ? 'DESC' : ''}`.trim()
+      this.refresh()
+    },
+
+    handleSelectAllOnPage ({ isChecked }) {
+      if (isChecked) {
+        this.$refs.table.selectAllRows()
+      } else {
+        this.$refs.table.clearSelected()
+      }
+    },
+
+    handleRowSelectCheckbox ({ index, isChecked }) {
+      if (isChecked) {
+        this.$refs.table.selectRow(index)
+      } else {
+        this.$refs.table.unselectRow(index)
+      }
+    },
+
+    handleRowSelected (selected) {
+      this.selected = selected
+    },
+
+    handleDeleteSelectedRecords () {
+      if (this.selected.length === 0) {
+        return
+      }
+
+      const { moduleID, namespaceID } = this.selected[0]
+
+      // Assuming all records are of same module & namespace
+      const recordIDs = this.selected
+        .filter(r => r.moduleID === moduleID && r.namespaceID === namespaceID)
+        .map(({ recordID }) => recordID)
+
+      this.$ComposeAPI
+        .recordBulkDelete({ moduleID, namespaceID, recordIDs })
+        .then(() => { this.refresh() })
+        .catch(this.stdErr)
+    },
+
+    refresh () {
+      this.$refs.table.refresh()
+    },
+
+    /**
+     * Loader for b-table
+     *
+     * Will ignore b-tables input arguments for filter
+     * and assemble them on our own
+     */
+    records () {
+      let filter = queryToFilter(this.query, '', this.module.filterFields(this.module.fields.slice(0, 5)))
+
+      const fieldsFilter = this.filterFields.items.filter(f => f.name).map(f => {
+        if (f.value) {
+          return `(${getFieldFilter(f, f.value)})`
+        } else {
+          return `(${f.name} IS NULL)`
+        }
+      }).join(' AND ')
+
+      if (fieldsFilter) {
+        if (filter) {
+          filter = `(${filter}) AND (${fieldsFilter})`
+        } else {
+          filter = `${fieldsFilter}`
+        }
+      }
+
+      return this.$ComposeAPI.recordList({ ...this.module, ...this.filter, filter })
+        .then(({ set, filter }) => {
+          const records = set.map(r => Object.freeze(new compose.Record(r, this.module)))
+
+          this.filter = { ...this.filter, ...filter }
+
+          // Extract user IDs from record values and load all users
+          const fields = this.fields.filter(f => f.moduleField).map(f => f.moduleField)
+          this.fetchUsers(fields, records)
+
+          return records
+        })
+        .catch(this.stdErr)
+    },
+
+    stdErr (err) {
+      /* eslint-disable no-console */
+      console.error(err)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+/deep/ table {
+  tbody {
+    tr {
+      td.record-value {
+        cursor: pointer;
+      }
+
+      th.selector, td.selector {
+        width: 25px !important;
+      }
+    }
+  }
+}
+
+.pointer {
+  cursor: pointer;
+}
+</style>

--- a/src/views/Admin/Modules/Records/List.vue
+++ b/src/views/Admin/Modules/Records/List.vue
@@ -251,7 +251,9 @@
       @ok="refresh()"
     >
       <b-container class="p-0">
+        <!-- @TODO This section is used for filtering deleter/undeleted records -->
         <b-form-group
+          v-if="false"
           :label="$t('block.recordList.filter.deletedRecords')"
         >
           <b-form-radio-group
@@ -267,7 +269,7 @@
             name="radio-btn-outline"
           />
         </b-form-group>
-        <hr>
+        <hr v-if="false">
         <p>
           <b>
             {{ $t('block.recordList.filter.byValue') }}

--- a/src/views/Admin/Modules/Records/View.vue
+++ b/src/views/Admin/Modules/Records/View.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="d-flex flex-column w-100 overflow-hidden">
+    <b-alert
+      v-if="isDeleted"
+      show
+      variant="info"
+      class="mb-0"
+    >
+      {{ $t('block.record.recordDeleted') }}
+    </b-alert>
+    <main
+      class="flex-grow-1 flex-wrap overflow-auto d-flex"
+      v-if="module && record"
+    >
+      <b-card
+        v-for="(fieldSet, index) in fields"
+        :key="index"
+        no-body
+        no-header
+        class="flex-grow-1 border-0 shadow-sm rounded-lg m-2"
+      >
+        <div
+          v-for="field in fieldSet"
+          :key="field.id"
+          class="p-2 border-bottom border-light"
+        >
+          <div
+            v-if="field.canReadRecordValue"
+            class="value"
+          >
+            <field-editor
+              v-if="field.canUpdateRecordValue && inEditing"
+              :namespace="$attrs.namespace"
+              :record="record"
+              :field="field"
+              :errors="fieldErrors(field.name)"
+            />
+
+            <div
+              v-else
+            >
+              <label
+                class="text-secondary small"
+              >
+                {{ field.label || field.name }}
+              </label>
+              <field-viewer
+                :namespace="$attrs.namespace"
+                :record="record"
+                :field="field"
+                value-only
+              />
+            </div>
+          </div>
+          <div
+            v-else
+            class="text-warning"
+          >
+            {{ $t('field.noPermission') }}
+          </div>
+        </div>
+      </b-card>
+    </main>
+    <record-toolbar
+      :module="module"
+      :isValid="isValid"
+      :isDeleted="isDeleted"
+      :inEditing="inEditing"
+      @add="handleAdd()"
+      @clone="handleClone()"
+      @edit="handleEdit()"
+      @delete="handleDelete()"
+      @back="handleBack()"
+      @submit="handleFormSubmit('admin.modules.record.view')"
+    />
+  </div>
+</template>
+
+<script>
+import FieldEditor from 'corteza-webapp-compose/src/components/ModuleFields/Editor'
+import FieldViewer from 'corteza-webapp-compose/src/components/ModuleFields/Viewer'
+import RecordToolbar from 'corteza-webapp-compose/src/components/Common/RecordToolbar'
+import users from 'corteza-webapp-compose/src/mixins/users'
+import record from 'corteza-webapp-compose/src/mixins/record'
+import { compose } from '@cortezaproject/corteza-js'
+
+export default {
+  components: {
+    RecordToolbar,
+    FieldViewer,
+    FieldEditor,
+  },
+
+  mixins: [
+    // The record mixin contains all of the logic for creating/editing/deleting the record
+    record,
+    users,
+  ],
+
+  computed: {
+    module () {
+      if (this.$attrs.moduleID) {
+        return this.getModuleByID(this.$attrs.moduleID)
+      } else {
+        return undefined
+      }
+    },
+
+    fields () {
+      if (!this.module) {
+        // No module, no fields
+        return []
+      }
+
+      const fields = []
+      const fieldSetSize = 8
+
+      let i, j
+      for (i = 0, j = this.module.fields.length; i < j; i += fieldSetSize) {
+        fields.push(this.module.fields.slice(i, i + fieldSetSize))
+      }
+
+      return fields
+    },
+
+    getUiEventResourceType () {
+      return 'admin-record-page'
+    },
+  },
+
+  watch: {
+    '$attrs.recordID': {
+      immediate: true,
+      handler () {
+        this.loadRecord()
+      },
+    },
+  },
+
+  methods: {
+    loadRecord () {
+      this.record = null
+      if (this.$attrs.recordID && this.$attrs.moduleID) {
+        const { namespaceID } = this.$attrs.namespace
+        const { moduleID, recordID } = this.$attrs
+        const module = Object.freeze(this.getModuleByID(moduleID).clone())
+        this.$ComposeAPI
+          .recordRead({ namespaceID, moduleID, recordID })
+          .then(record => {
+            this.record = new compose.Record(module, record)
+            this.fetchUsers(this.module.fields, [this.record])
+          })
+          .catch(this.defaultErrorHandler(this.$t('notification.record.loadFailed')))
+      }
+    },
+
+    handleBack () {
+      this.$router.push({ name: 'admin.modules.record.list', params: { moduleID: this.module.moduleID } })
+    },
+
+    handleAdd () {
+      this.$router.push({ name: 'admin.modules.record.create', params: { moduleID: this.module.moduleID } })
+    },
+
+    handleClone () {
+      this.$router.push({ name: 'admin.modules.record.create', params: { moduleID: this.module.moduleID, values: this.record.values } })
+    },
+
+    handleEdit () {
+      this.$router.push({ name: 'admin.modules.record.edit', params: this.$route.params })
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.value {
+  min-height: 1.2rem;
+}
+</style>

--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -16,95 +16,39 @@
     />
 
     <portal to="toolbar">
-      <b-container
-        fluid
-        class="bg-white shadow border-top py-3 px-3 m-0"
-      >
-        <b-row
-          no-gutters
-        >
-          <b-col cols="4">
-            <b-button
-              variant="link"
-              @click.prevent="$router.back()"
-            >
-              &#171; {{ $t('general.label.back') }}
-            </b-button>
-          </b-col>
-          <b-col
-            cols="4"
-            class="text-center"
-          >
-            <b-button
-              v-if="module.canCreateRecord"
-              variant="outline-secondary"
-              class="m-1"
-              @click.prevent="$router.push({ name: 'page.record.create', params: { pageID: page.pageID, values: record.values }})"
-            >
-              {{ $t('general.label.clone') }}
-            </b-button>
-
-            <b-button
-              v-if="module.canCreateRecord"
-              variant="outline-secondary"
-              class="m-1"
-              @click.prevent="$router.push({ name: 'page.record.create', params: newRouteParams })"
-            >
-              {{ $t('general.label.addNew') }}
-            </b-button>
-          </b-col>
-          <b-col
-            cols="4"
-            class="text-right"
-          >
-            <c-input-confirm
-              :disabled="!module.canDeleteRecord || isDeleted"
-              @confirmed="handleDelete()"
-              class="m-1"
-            >
-              {{ $t('general.label.delete') }}
-            </c-input-confirm>
-
-            <b-button
-              v-if="module.canUpdateRecord && !isDeleted && !inEditing"
-              variant="outline-secondary"
-              class="m-1"
-              @click.prevent="$router.push({ name: 'page.record.edit', params: $route.params })"
-            >
-              {{ $t('general.label.edit') }}
-            </b-button>
-
-            <b-button
-              v-else-if="module.canUpdateRecord"
-              :disabled="!isValid || isDeleted"
-              class="m-1"
-              variant="primary"
-              @click.prevent="handleFormSubmit"
-            >
-              {{ $t('general.label.save') }}
-            </b-button>
-          </b-col>
-        </b-row>
-      </b-container>
+      <record-toolbar
+        :module="module"
+        :isValid="isValid"
+        :isDeleted="isDeleted"
+        :inEditing="inEditing"
+        @add="handleAdd()"
+        @clone="handleClone()"
+        @edit="handleEdit()"
+        @delete="handleDelete()"
+        @back="handleBack()"
+        @submit="handleFormSubmit('page.record')"
+      />
     </portal>
-    <b-modal size="lg" id="deleteRecord" :title="$t('block.record.deleteRecord')" @ok="handleDelete" :ok-title="$t('general.label.delete')" ok-variant="danger">
-      <div class="d-block text-center">
-        <h3>{{ $t('block.record.confirmDelete') }}</h3>
-      </div>
-    </b-modal>
   </div>
 </template>
 <script>
-import { mapGetters } from 'vuex'
 import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
-import { compose, validator, NoID } from '@cortezaproject/corteza-js'
+import RecordToolbar from 'corteza-webapp-compose/src/components/Common/RecordToolbar'
+import record from 'corteza-webapp-compose/src/mixins/record'
+import { compose } from '@cortezaproject/corteza-js'
 
 export default {
   name: 'ViewRecord',
 
   components: {
     Grid,
+    RecordToolbar,
   },
+
+  mixins: [
+    // The record mixin contains all of the logic for creating/editing/deleting the record
+    record,
+  ],
 
   props: {
     namespace: {
@@ -128,45 +72,14 @@ export default {
     },
   },
 
-  data () {
-    return {
-      inEditing: false,
-      record: undefined,
-      errors: new validator.Validated(),
-    }
-  },
-
   computed: {
-    ...mapGetters({
-      getModuleByID: 'module/getByID',
-    }),
-
     newRouteParams () {
       const { recordID, ...params } = this.$route.params
       return params
     },
 
-    validator () {
-      if (!this.module) {
-        throw new Error('can not initialize record validator without module')
-      }
-
-      return new compose.RecordValidator(this.module)
-    },
-
-    isValid () {
-      return this.errors.valid()
-    },
-
-    /**
-     * Tells if given record is deleted; If record not provided, returns undefined
-     * @returns {Boolean|undefined}
-     */
-    isDeleted () {
-      if (!this.record) {
-        return
-      }
-      return !!this.record.deletedAt
+    getUiEventResourceType () {
+      return 'record-page'
     },
   },
 
@@ -175,14 +88,6 @@ export default {
       immediate: true,
       handler () {
         this.loadRecord()
-      },
-    },
-    'record.values': {
-      deep: true,
-      handler () {
-        if (!this.errors.valid()) {
-          this.errors = this.validator.run(this.record)
-        }
       },
     },
   },
@@ -206,113 +111,16 @@ export default {
       this.$router.back()
     },
 
-    /**
-     * On delete, preserve user's view. Show a notification that the record
-     * has been deleted.
-     */
-    handleDelete () {
-      return this
-        .dispatchUiEvent('beforeDelete')
-        .then(() => this.$ComposeAPI.recordDelete(this.record))
-        .then(() => {
-          this.record.deletedAt = (new Date()).toISOString()
-        })
-        .then(() => this.dispatchUiEvent('afterDelete'))
-        .catch(this.defaultErrorHandler(this.$t('notification.record.deleteFailed')))
+    handleAdd () {
+      this.$router.push({ name: 'page.record.create', params: this.newRouteParams })
     },
 
-    /**
-     * Handle form submit for record create & update
-     *
-     *  -> dispatch beforeFormSubmit (on ui:compose:record-page)
-     *  -> validate record (see validateRecord())
-     *     -> stop on errors
-     *  -> send record to the API
-     *  -> apply changes received from the API to current record
-     *  -> dispatch afterFormSubmit
-     *  -> redirect user to record viewer page
-     *
-     * @returns {Promise<void>}
-     */
-    handleFormSubmit (ev) {
-      const isNew = this.record.recordID === NoID
-
-      return this
-        .dispatchUiEvent('beforeFormSubmit')
-        .then(() => this.validateRecord())
-        .then(() => {
-          if (isNew) {
-            return this.$ComposeAPI.recordCreate(this.record)
-          } else {
-            return this.$ComposeAPI.recordUpdate(this.record)
-          }
-        })
-        .catch(err => {
-          const { details = undefined } = err
-          if (!!details && Array.isArray(details) && details.length > 0) {
-            this.errors.push(...details)
-            throw new Error(this.$t('notification.record.validationErrors'))
-          }
-
-          throw err
-        })
-        .then((record) => this.record.apply(record))
-        .then(() => this.dispatchUiEvent('afterFormSubmit'))
-        .then(() => {
-          this.$router.push({ name: 'page.record', params: { ...this.$route.params, recordID: this.record.recordID } })
-        })
-        .catch(this.defaultErrorHandler(this.$t(
-          isNew
-            ? 'notification.record.createFailed'
-            : 'notification.record.updateFailed',
-        )))
+    handleClone () {
+      this.$router.push({ name: 'page.record.create', params: { pageID: this.page.pageID, values: this.record.values } })
     },
 
-    /**
-     * Validates record and dispatches onFormSubmitError
-     *
-     * onFormSubmitError is dispatched only if there are record errors,
-     * if not, we continue with form submit handling
-     *
-     * After onFormSubmitError, record is re-validated and if errors
-     * are still present, we stop form submit handing
-     *
-     * @returns {Promise<void>}
-     */
-    async validateRecord () {
-      this.errors = this.validator.run(this.record)
-      if (this.errors.valid()) {
-        return
-      }
-
-      await this.dispatchUiEvent('onFormSubmitError')
-
-      this.errors = this.validator.run(this.record)
-      if (!this.errors.valid()) {
-        throw new Error(this.$t('notification.record.validationErrors'))
-      }
-    },
-
-    /**
-     * Generic event dispatcher for ui:compose:record-page resource type
-     *
-     * This is used when deleting, updating, creating
-     * records and where validation errors occur
-     *
-     * @param eventType
-     */
-    dispatchUiEvent (eventType) {
-      const resourceType = 'ui:compose:record-page'
-
-      const args = {
-        errors: this.errors,
-        validator: this.validator,
-      }
-
-      return this
-        .$EventBus
-        .Dispatch(compose.RecordEvent(
-          this.record, { eventType, resourceType, args }))
+    handleEdit () {
+      this.$router.push({ name: 'page.record.edit', params: this.$route.params })
     },
   },
 }

--- a/src/views/routes.js
+++ b/src/views/routes.js
@@ -40,6 +40,10 @@ export default [
         children: [
           r('admin.modules', 'modules', 'Admin/Modules/Index'),
           r('admin.modules.edit', 'modules/:moduleID/edit', 'Admin/Modules/Edit'),
+          r('admin.modules.record.list', 'modules/:moduleID/record/list', 'Admin/Modules/Records/List'),
+          r('admin.modules.record.view', 'modules/:moduleID/record/:recordID', 'Admin/Modules/Records/View'),
+          r('admin.modules.record.create', 'modules/:moduleID/record', 'Admin/Modules/Records/Create'),
+          r('admin.modules.record.edit', 'modules/:moduleID/record/:recordID/edit', 'Admin/Modules/Records/Edit'),
 
           r('admin.pages', 'pages', 'Admin/Pages/Index'),
           r('admin.pages.edit', 'pages/:pageID/edit', 'Admin/Pages/Edit'),


### PR DESCRIPTION
This feature enables the viewing of all records for a specific module, even if the module doesn't have a record page configured. 

WIP:
- [x] Filtering records by deleted is still waiting for API implementation @darh 
- [ ] Introduce render only record list component. I have the component ready, the only problem is the way we wrap the RecordList. Its wrapped by a component with three slots(/Wrap/Card.vue). Which i cant then use in the render only component since the root of a component should only contain one element. And the slots must be placed in wrapped element root... Wasted quite a bit of my time on this problem...  @Fajfa 
- [x] Bool field filtering, the way its implemented now doesnt seem to work. It checks if the Bool value is 'true' or 'false', but Bool field values are either '1' or '0'. @darh 

Views:

- Record list:
Takes the first 5 fields defined in the module and uses them as fields for the table. 
![Screenshot from 2020-04-28 19-05-23](https://user-images.githubusercontent.com/15791641/80516317-93b42800-8983-11ea-8ed5-932284253105.png)

- Record list field filter:
User can search fields for specific values. If field value is empty the request returns records where the value of that field is undefined/NULL
![Screenshot from 2020-04-28 19-05-56](https://user-images.githubusercontent.com/15791641/80516341-9d3d9000-8983-11ea-935f-70af6beb9ba1.png)

- Record view
Auto generated record blocks. 10 fields per record block. The record blocks use flex-grow, so they expand and shrink based on the content.
![Screenshot from 2020-04-28 19-08-47](https://user-images.githubusercontent.com/15791641/80516404-b3e3e700-8983-11ea-8bd6-dc34de19c372.png)

- Record edit
![Screenshot from 2020-04-28 19-07-32](https://user-images.githubusercontent.com/15791641/80516433-bfcfa900-8983-11ea-83c9-838fad2e213f.png)

