### PR TITLE
Add support for record field prefiltering

### DIFF
--- a/src/components/ModuleFields/Configurator/Record.vue
+++ b/src/components/ModuleFields/Configurator/Record.vue
@@ -63,6 +63,21 @@
         :disabled="!module"
       />
     </b-form-group>
+    <b-form-group>
+      <label
+        class="d-block"
+      >
+        {{ $t('field.kind.record.prefilterLabel') }}
+      </label>
+      <b-form-textarea
+        v-model="f.options.prefilter"
+        class="form-control"
+        :placeholder="$t('field.kind.record.prefilterPlaceholder')"
+      />
+      <b-form-text>
+        {{ $t('field.kind.record.prefilterFootnote') }}
+      </b-form-text>
+    </b-form-group>
     <b-form-group v-if="field.isMulti">
       <label
         class="d-block"

--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -806,6 +806,9 @@ export default {
         recordFieldPlaceholder: 'Pick field',
         queryFieldsLabel: 'Query fields on search',
         suggestionPlaceholder: 'Start typing to search for records',
+        prefilterLabel: 'Prefilter records',
+        prefilterPlaceholder: 'field1 = 1 AND field2 = 232',
+        prefilterFootnote: 'Simplified SQL condition (WHERE ...) syntax is supported.',
       },
       string: {
         label: 'String',


### PR DESCRIPTION
This adds a prefilter option on the record module field configurator (translations are added).

![image](https://user-images.githubusercontent.com/12545711/81685411-5312df00-9458-11ea-9ab1-668e624ea167.png)
![image](https://user-images.githubusercontent.com/12545711/81685455-58702980-9458-11ea-9fbe-1d94ceb77cb4.png)
