### PR TITLE
Improve page reorder

### DIFF
--- a/src/components/Admin/Page/Tree.vue
+++ b/src/components/Admin/Page/Tree.vue
@@ -161,6 +161,7 @@ export default {
         const pageIDs = afterParent.children.map(p => p.pageID)
         if (pageIDs.length > 1) {
           this.$ComposeAPI.pageReorder({ namespaceID, selfID: afterID, pageIDs: pageIDs }).then(() => {
+            this.$store.dispatch('page/load', { namespaceID, clear: true, force: true })
             this.raiseSuccessAlert(this.$t('notification.page.reordered'))
             this.$emit('reorder')
           }).catch(this.defaultErrorHandler(this.$t('notification.page.pageMoveFailed')))

--- a/src/views/Admin/Pages/Index.vue
+++ b/src/views/Admin/Pages/Index.vue
@@ -86,6 +86,7 @@ export default {
 
     handleAddPageFormSubmit () {
       const { namespaceID } = this.namespace
+      this.page.weight = this.tree.length
       this.createPage({ ...this.page, namespaceID }).then(({ pageID }) => {
         this.$router.push({ name: 'admin.pages.edit', params: { pageID } })
       }).catch(this.defaultErrorHandler(this.$t('notification.page.saveFailed')))


### PR DESCRIPTION
Changes:
- The pages in store are now reloaded after a page is reordered

- When a new page is created, it is placed on the bottom of the page tree