### PR TITLE
Await loading record for grid

### DIFF
--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -97,17 +97,18 @@ export default {
     recordID: {
       immediate: true,
       handler () {
+        this.record = undefined
         this.loadRecord()
       },
     },
   },
 
   methods: {
-    loadRecord () {
+    async loadRecord () {
       if (this.page && this.recordID && this.page.moduleID) {
         const { namespaceID, moduleID } = this.page
         const module = Object.freeze(this.getModuleByID(moduleID).clone())
-        this.$ComposeAPI
+        await this.$ComposeAPI
           .recordRead({ namespaceID, moduleID, recordID: this.recordID })
           .then(record => {
             this.record = new compose.Record(module, record)


### PR DESCRIPTION
Record loading wasnt awaited so the wrong record was used when coming from another record page.