### PR TITLE
Sysfields display and restrict sorting on specific fields

### DIFF
--- a/src/components/Common/Module/FieldPicker.vue
+++ b/src/components/Common/Module/FieldPicker.vue
@@ -7,7 +7,8 @@
           <draggable
             class="drag-area border"
             :list.sync="availableFields"
-            :options="{ group: 'fields', sort: false }">
+            :group="group"
+          >
             <div v-for="field in availableFields"
                  @dblclick="selectedFields.push(field)"
                  class="field"
@@ -21,11 +22,12 @@
         </div>
         <div class="selected">
           <label>{{ $t('field.selector.selected') }}</label>
-          <b-button @click.prevent="selectedFields.splice(0)" variant="link" class="float-right">{{ $t('field.selector.unselectAll') }}</b-button>
+          <b-button @click.prevent="selectedFields = []" variant="link" class="float-right">{{ $t('field.selector.unselectAll') }}</b-button>
           <draggable
             class="drag-area border"
-            :list.sync="selectedFields"
-            :options="{ group:'fields' }">
+            v-model="selectedFields"
+            :group="group"
+          >
             <div v-for="(field, index) in selectedFields"
                  @dblclick="selectedFields.splice(index,1)"
                  class="field"
@@ -79,6 +81,11 @@ export default {
       type: Array,
       default: null,
     },
+
+    group: {
+      type: String,
+      default: 'fields',
+    },
   },
 
   data () {
@@ -90,7 +97,7 @@ export default {
   computed: {
     selectedFields: {
       get () {
-        return this.fields
+        return this.allFields.filter(a => this.fields.some(f => a.name === f.name))
       },
 
       set (f) {
@@ -101,7 +108,7 @@ export default {
     allFields () {
       let mFields = []
       if (this.fieldSubset) {
-        mFields = this.fieldSubset
+        mFields = this.module.filterFields(this.fieldSubset)
       } else {
         mFields = this.module.fields
       }
@@ -127,14 +134,8 @@ export default {
     },
 
     availableFields () {
-      let fields = [...this.allFields]
-
       // Remove selected fields
-      fields = fields.filter(a =>
-        !this.fields.find(f => a.name === f.name),
-      )
-
-      return fields
+      return this.allFields.filter(a => !this.fields.some(f => a.name === f.name))
     },
   },
 

--- a/src/components/ModuleFields/Editor/index.vue
+++ b/src/components/ModuleFields/Editor/index.vue
@@ -1,13 +1,10 @@
 <script>
-import * as Editors from './loader'
-import { User as UserViewer, DateTime as DateTimeViewer } from '../Viewer/loader'
 import base from './base'
+import * as Editors from './loader'
 
 export default {
   components: {
     ...Editors,
-    UserViewer,
-    DateTimeViewer,
   },
 
   extends: base,
@@ -15,16 +12,6 @@ export default {
   computed: {
     component () {
       const kind = this.field.kind.toLocaleLowerCase()
-
-      if (this.field.isSystem) {
-        switch (this.field.kind) {
-          case 'User':
-            return UserViewer
-          case 'DateTime':
-            return DateTimeViewer
-        }
-      }
-
       const keys = Object.keys(this.$options.components)
       const i = keys.map(c => c.toLocaleLowerCase()).findIndex(c => c === kind)
 

--- a/src/components/PageBlocks/RecordEditor.vue
+++ b/src/components/PageBlocks/RecordEditor.vue
@@ -2,11 +2,12 @@
   <wrap v-bind="$props" v-on="$listeners">
     <div
       v-if="record"
-      class="mt-3 px-3"
+      class="px-3"
     >
       <div
         v-for="field in fields"
         :key="field.id"
+        class="mt-3"
       >
         <field-editor
           v-if="isFieldEditable(field)"
@@ -15,28 +16,32 @@
           :field="field"
         />
         <div
-          v-else-if="field.canReadRecordValue"
-          class="field"
+          v-else
         >
           <label
             class="text-primary"
           >
             {{ field.label || field.name }}
           </label>
-          <field-viewer
-            :field="field"
-            v-bind="{ ...$props, errors: fieldErrors(field.name) }"
-          />
-        </div>
-        <div
-          v-else
-        >
-          <label>{{ field.label || field.name }}</label>
-          <i
-            class="text-dark"
+          <div
+            v-if="field.canReadRecordValue"
+            class="value"
           >
-            {{ $t('field.noPermission') }}
-          </i>
+            <field-viewer
+              :field="field"
+              v-bind="{ ...$props, errors: fieldErrors(field.name) }"
+              value-only
+            />
+          </div>
+          <div
+            v-else
+          >
+            <i
+              class="text-warning"
+            >
+              {{ $t('field.noPermission') }}
+            </i>
+          </div>
         </div>
       </div>
     </div>
@@ -121,6 +126,7 @@ export default {
     isFieldEditable (field) {
       return field &&
         field.canUpdateRecordValue &&
+        !field.isSystem &&
         !(
           field.expressions &&
           field.expressions.value

--- a/src/components/PageBlocks/RecordListBase.vue
+++ b/src/components/PageBlocks/RecordListBase.vue
@@ -679,7 +679,7 @@ export default {
         key: mf.name,
         label: mf.label || mf.name,
         moduleField: mf,
-        sortable: !this.options.hideSorting && !(this.options.editable && this.editing) && !mf.isMulti,
+        sortable: !this.options.hideSorting && !(this.options.editable && this.editing) && !mf.isMulti && mf.isSortable,
         tdClass: 'record-value',
         editable: !!editable.find(f => mf.name === f),
         required: this.inlineEditing && mf.isRequired,

--- a/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/src/components/PageBlocks/RecordListConfigurator.vue
@@ -64,6 +64,7 @@
             :module="recordListModule"
             :field-subset="options.fields"
             :fields.sync="options.editFields"
+            group="edit-fields"
             disable-system-fields
           />
         </b-form-group>
@@ -330,6 +331,10 @@ export default {
 
       this.options.hideSorting = true
       this.options.presort = ''
+    },
+
+    'options.fields' (fields) {
+      this.options.editFields = this.options.editFields.filter(a => fields.some(b => a.name === b.name))
     },
   },
 }

--- a/src/views/Admin/Modules/Records/List.vue
+++ b/src/views/Admin/Modules/Records/List.vue
@@ -471,7 +471,7 @@ export default {
           key: mf.name,
           label: mf.label || mf.name,
           moduleField: mf,
-          sortable: true,
+          sortable: !mf.isMulti && mf.isSortable,
           tdClass: 'record-value',
         }))
 


### PR DESCRIPTION
Fixes the way we display sysfields in record editor so it is the same as they are displayed in record viewer.

Before:
![1](https://user-images.githubusercontent.com/15791641/114170246-ed162c80-9932-11eb-9f53-ab35b3ce175b.png)

After:
![2](https://user-images.githubusercontent.com/15791641/114170221-e4255b00-9932-11eb-8617-b5726f6ad374.png)

Changes in `src/components/ModuleFields/Editor/index.vue`:
Moves logic that controls the display of sysfields from fieldEditor and instead filters out system fields in the parent component.
I checked and we do this everywhere but on fieldEditor. Seemed like better practice, can remove from PR.
I did this to prevent nesting of components. 
The sysfields in recordEditor were first displayed as fieldEditor and then inside that component the related sysfield fieldViewer was rendered so the components were nested.

