### PR TITLE
Implement NoID check to avoid error() on creation

### DIFF
--- a/src/components/Chart/index.vue
+++ b/src/components/Chart/index.vue
@@ -10,6 +10,7 @@ import ChartJS from 'chart.js'
 import Funnel from 'chartjs-plugin-funnel'
 import Gauge from 'chartjs-gauge'
 import csc from 'chartjs-plugin-colorschemes'
+import { NoID } from '@cortezaproject/corteza-js'
 
 export default {
   props: {
@@ -40,9 +41,11 @@ export default {
   },
 
   mounted () {
-    this.$nextTick(() => {
-      this.updateChart()
-    })
+    if (this.chart.chartID !== NoID) {
+      this.$nextTick(() => {
+        this.updateChart()
+      })
+    }
 
     this.$root.$on('chart.update', this.requestChartUpdate)
   },


### PR DESCRIPTION
This change will avoid having a "missingModuleID" on creation of a Chart