### PR TITLE
Modify default field value logic

### DIFF
--- a/src/i18n/en/compose.js
+++ b/src/i18n/en/compose.js
@@ -961,7 +961,8 @@ export default {
 
   field: {
     noPermission: 'No permission to read field value',
-    defaultValue: 'Default field value',
+    defaultValue: 'Default value',
+    defaultFieldValue: 'Default field value',
     options: {
       multiDelimiter: {
         label: 'Multiple value delimiter',


### PR DESCRIPTION
If default value checkbox is not checked. There will be no default value. 

Otherwise the value provided is saved. 

Boolean example:
 - Default value not checked (undefined)
 - Default value checked but checkbox not checked (false)
 - Default value checked and checkbox checked (true)

Exception, multi value fields now must have a default value. Cannot differentiate between not set values since multi field empty array is a legit value.

![image](https://user-images.githubusercontent.com/15791641/127361420-071d8249-4cd4-433d-977c-5886907de607.png)

![image](https://user-images.githubusercontent.com/15791641/127361477-a7588352-0592-4feb-903e-6edd854eaf7e.png)
