### PR TITLE
Remove h-100 to card-body

### DIFF
--- a/src/components/PageBlocks/Wrap/Card.vue
+++ b/src/components/PageBlocks/Wrap/Card.vue
@@ -35,7 +35,7 @@
         />
       </div>
       <b-card-body
-        class="p-0 h-100"
+        class="p-0"
         :class="{ 'overflow-auto': scrollableBody }"
       >
         <slot


### PR DESCRIPTION
Remove breaking "h-100" class on \<b-card-body\> because every "card-child" elements are "flex-item" and fixing the height to one of them will force the size of this one to "as far as possible" and reduce the other ones, leading to the crop of Title and Description if block doesn't have enough height (which can need a lot !).
![descriptionText](https://user-images.githubusercontent.com/86595459/127826326-6ef549b2-6f76-4726-8eda-13fc95a42946.png)
