### PR TITLE
2021.3.x fix recordlist configuration after yaml import

### DIFF
--- a/src/components/Common/Module/FieldPicker.vue
+++ b/src/components/Common/Module/FieldPicker.vue
@@ -99,7 +99,7 @@ export default {
       get () {
         // Needs to be done this way so it retains order of fields
         return this.fields.reduce((fields, field) => {
-          field = this.allFields.find(({ name }) => name === field.name)
+          field = this.allFields.find(({ name }) => name === (field.name || field))
           if (field) {
             fields.push(field)
           }
@@ -142,7 +142,7 @@ export default {
 
     availableFields () {
       // Remove selected fields
-      return this.allFields.filter(a => !this.fields.some(f => a.name === f.name))
+      return this.allFields.filter(a => !this.fields.some(f => a.name === (f.name || f)))
     },
   },
 


### PR DESCRIPTION
When using a recordlist, the selected fields in FieldPicker.vue is an array of object.

![exported](https://user-images.githubusercontent.com/82505474/128023970-9651dacb-2db6-4bbd-b9f8-d35c0a8fb886.png)

But when a page that contain a recordlist is exported (with `server export`), and then imported from yaml provision,
`this.fields` (used in `selectedFields` computed)is an array of string instead of a an array of object

![imported](https://user-images.githubusercontent.com/82505474/128023537-069bfab9-b1ef-4edf-a345-cfa6cf2646a5.png)

FieldPicker don't handle it and don't display the selected columns
To fix it, we can use `field` (that contain the name when the page is imported) when `field.name` is undefined 

The same goes for availableFields otherwise the Columns available will also contain the selected fields