### PR TITLE
2021.9.x feature c3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "dev-env": "vue-cli-service serve src/dev-env.js",
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint && stylelint '**/*.{vue,scss}' --fix",
     "test:unit": "vue-cli-service test:unit",

--- a/src/components/Admin/C3.js
+++ b/src/components/Admin/C3.js
@@ -1,0 +1,3 @@
+export { default as FieldRowEdit } from './Module/FieldRowEdit.c3'
+// disabled: uses store
+// export { default as Tree } from './Page/Tree.c3'

--- a/src/components/Admin/EditorToolbar.c3.js
+++ b/src/components/Admin/EditorToolbar.c3.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line
+import { default as component } from './EditorToolbar.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox } = components.C3.controls
+
+const props = {
+  backLink: {},
+  hideDelete: false,
+  hideSave: false,
+  disableSave: false,
+}
+
+export default {
+  name: 'Editor toolbar',
+  group: ['Admin'],
+  component,
+  props,
+
+  controls: [
+    checkbox('Hide delete', 'hideDelete'),
+    checkbox('Hide save', 'hideSave'),
+    checkbox('Disable save', 'disableSave'),
+  ],
+}

--- a/src/components/Admin/Module/FieldRowEdit.c3.js
+++ b/src/components/Admin/Module/FieldRowEdit.c3.js
@@ -1,0 +1,74 @@
+// eslint-disable-next-line
+import { default as component } from './FieldRowEdit.vue'
+import { compose } from '@cortezaproject/corteza-js'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox } = components.C3.controls
+
+const props = {
+  value: {
+    name: 'Name',
+    label: 'Label',
+    kind: 'String',
+    cap: {
+      configurable: true,
+      multi: true,
+      required: true,
+      private: false,
+    },
+    isMulti: true,
+    isRequired: true,
+    isPrivate: false,
+    fieldId: '453534534534343',
+    isValid: true,
+  },
+  module: new compose.Module({
+    namespaceID: '3242343234',
+    moduleID: '999999442',
+  }),
+  canGrant: true,
+  hasRecords: false,
+}
+
+export default {
+  name: 'Field row edit',
+  group: ['Admin', 'Module'],
+  component,
+  props,
+  controls: [
+    checkbox('configurable', 'cap.configurable'),
+    checkbox('multi', 'value.cap.multi'),
+    checkbox('required', 'value.cap.required'),
+    checkbox('private', 'value.cap.private'),
+    checkbox('isMulti', 'value.isMulti'),
+    checkbox('isRequired', 'value.isRequired'),
+    checkbox('isPrivate', 'value.isPrivate'),
+    checkbox('isValid', 'value.isValid'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        canGrant: false,
+        hasRecords: true,
+        value: {
+          cap: {
+            configurable: false,
+            multi: false,
+            required: false,
+            private: false,
+          },
+          isMulti: false,
+          isRequired: false,
+          isPrivate: false,
+          isValid: false,
+        },
+      },
+    },
+  ],
+}

--- a/src/components/Admin/Page/Tree.c3.js
+++ b/src/components/Admin/Page/Tree.c3.js
@@ -1,0 +1,69 @@
+// eslint-disable-next-line
+import { default as component } from './Tree.vue'
+import { compose } from '@cortezaproject/corteza-js'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+// TypeError: Cannot read property 'getters' of undefined at VueComponent.mappedGetter
+const props = {
+  namespace: new compose.Namespace({
+    canCreatePage: true,
+    canGrant: true,
+    namespaceID: '',
+  }),
+  value: [
+    {
+      pageID: '44444444444',
+      moduleID: '324234324',
+      title: 'Home',
+      handle: 'Home',
+      visible: true,
+      canGrant: true,
+      canUpdatePage: true,
+      blocks: [{
+        kind: 'RecordList',
+        title: 'My New Leads',
+      }],
+    },
+    {
+      pageID: '456454644444',
+      moduleID: '004234324',
+      title: 'Test',
+      handle: 'Test',
+      visible: true,
+      canGrant: true,
+      canUpdatePage: true,
+      blocks: [{
+        kind: 'RecordList',
+        title: 'My New Leads',
+      }],
+    },
+  ],
+  parentID: '',
+  level: 0,
+}
+
+export default {
+  name: 'Tree WIP',
+  group: ['Admin', 'Page'],
+  component,
+  props,
+  controls: [],
+  // controls: [
+  //   checkbox('', ''),
+  //   input(' of step', ''),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/C3.js
+++ b/src/components/C3.js
@@ -1,0 +1,23 @@
+import * as admin from './Admin/C3'
+import * as chart from './Chart/C3'
+import * as common from './Common/C3'
+import * as moduleFields from './ModuleFields/C3'
+import * as namespace from './Namespaces/C3'
+import * as publicCmps from './Public/C3'
+import * as rightPanel from './RightPanel/C3'
+import { pageBlockBase, pageBlockConfigurators } from './PageBlocks/C3'
+
+import FileConfigurator from './Admin/EditorToolbar.c3'
+
+export default {
+  ...admin,
+  ...chart,
+  ...common,
+  ...moduleFields,
+  ...namespace,
+  ...pageBlockConfigurators,
+  ...pageBlockBase,
+  ...publicCmps,
+  ...rightPanel,
+  FileConfigurator,
+}

--- a/src/components/Chart/C3.js
+++ b/src/components/Chart/C3.js
@@ -1,0 +1,2 @@
+export { default as ReportEdit } from './Report/ReportEdit.c3'
+export { default as ReportItem } from './ReportItem.c3'

--- a/src/components/Chart/Report/ReportEdit.c3.js
+++ b/src/components/Chart/Report/ReportEdit.c3.js
@@ -1,0 +1,89 @@
+// eslint-disable-next-line
+import { default as component } from './ReportEdit.vue'
+
+const props = {
+  report: {
+    moduleID: '',
+    filter: '',
+    colorScheme: '#fffff',
+    metrics: [
+      {
+        aggregate: 'AVG',
+        field: 'count',
+        moduleID: '',
+      },
+    ],
+    dimensions: [{
+      field: 'Rating',
+      modifier: '(no grouping / buckets)',
+      skipMissing: true,
+      default: '',
+    }],
+  },
+  modules: [
+    {
+      moduleID: '',
+      handle: 'Pool',
+      name: 'Pool',
+      fields: [{
+        kind: 'String',
+        name: 'Sample',
+        options: {
+          multiLine: false,
+          useRichTextEditor: false,
+        },
+      }],
+    },
+    {
+      moduleID: '',
+      handle: 'Party',
+      name: 'Party',
+      fields: [{
+        kind: 'String',
+        name: 'Party',
+        options: {
+          multiLine: false,
+          useRichTextEditor: false,
+        },
+      }],
+    },
+    {
+      moduleID: '',
+      handle: 'Test',
+      name: 'Test',
+      fields: [{
+        kind: 'String',
+        name: 'Test',
+        options: {
+          multiLine: false,
+          useRichTextEditor: false,
+        },
+      }],
+    },
+  ],
+  supportedMetrics: -1,
+  dimensionFieldKind: ['DateTime', 'Select', 'Number', 'Bool', 'String'],
+  unSkippable: false,
+}
+
+export default {
+  name: 'Edit',
+  group: ['Chart', 'Report'],
+  component,
+  props,
+  controls: [],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        modules: [],
+      },
+    },
+  ],
+}

--- a/src/components/Chart/ReportItem.c3.js
+++ b/src/components/Chart/ReportItem.c3.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line
+import { default as component } from './ReportItem.vue'
+
+const props = {
+  report: {},
+  fixed: true,
+}
+
+export default {
+  name: 'Report item',
+  group: ['Chart'],
+  component,
+  props,
+  controls: [
+  ],
+}

--- a/src/components/Common/C3.js
+++ b/src/components/Common/C3.js
@@ -1,0 +1,7 @@
+export { default as CircleStep } from './CircleStep.c3'
+export { default as Grid } from './Grid.c3'
+export { default as Hint } from './Hint.c3'
+// disabled: waiting for TJ to explain te use
+// export { default as ItemPicker } from './ItemPicker.c3'
+export { default as RecordListFilter } from './RecordListFilter.c3'
+export { default as FieldPicker } from './Module/FieldPicker.c3'

--- a/src/components/Common/CircleStep.c3.js
+++ b/src/components/Common/CircleStep.c3.js
@@ -1,0 +1,26 @@
+// eslint-disable-next-line
+import { default as component } from './CircleStep.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox, input } = components.C3.controls
+
+const props = {
+  done: true,
+  disabled: false,
+  optional: false,
+  small: false,
+  stepNumber: '111',
+}
+
+export default {
+  name: 'Circle step',
+  group: ['Common'],
+  component,
+  props,
+
+  controls: [
+    checkbox('Done', 'done'),
+    checkbox('Disabled', 'disabled'),
+    checkbox('Small', 'small'),
+    input('Number of step', 'stepNumber'),
+  ],
+}

--- a/src/components/Common/Grid.c3.js
+++ b/src/components/Common/Grid.c3.js
@@ -1,0 +1,53 @@
+// eslint-disable-next-line
+import { default as component } from './Grid.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox } = components.C3.controls
+
+const props = {
+  editable: true,
+  blocks: [
+    {
+      description: 'Description',
+      kind: 'Chart',
+      options: { chartID: '242313186186166275' },
+      style: {
+        variants: {
+          bodyBg: 'white',
+          border: 'primary',
+          headerBg: 'white',
+          headerText: 'primary',
+        },
+        title: 'Title',
+        wrap: {
+          kind: 'card',
+        },
+      },
+      title: 'Leads by type',
+      xywh: [9, 32, 3, 8],
+    },
+  ],
+}
+
+export default {
+  name: 'Grid',
+  group: ['Common'],
+  component,
+  props,
+  controls: [
+    checkbox('Editable', 'editable'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        editable: false,
+      },
+    },
+  ],
+}

--- a/src/components/Common/Hint.c3.js
+++ b/src/components/Common/Hint.c3.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line
+import { default as component } from './Hint.vue'
+
+const props = {
+  text: 'I\'m the hint!',
+  id: '34324',
+}
+
+export default {
+  name: 'Hint',
+  group: ['Common'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Common/ItemPicker.c3.js
+++ b/src/components/Common/ItemPicker.c3.js
@@ -1,0 +1,41 @@
+// eslint-disable-next-line
+import { default as component } from './ItemPicker.vue'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+const props = {
+  // slots
+  keyProp: 'value',
+  items: [
+    {
+      text: 'Customer Referral',
+      value: 'Customer Referral',
+      color: undefined,
+    },
+    {
+      text: 'Direct',
+      value: 'Direct',
+      color: undefined,
+    },
+    {
+      text: 'Employee Referral',
+      value: 'Employee Referral',
+      color: undefined,
+    },
+  ],
+  selected: [
+    // {
+    //   color: undefined,
+    //   text: 'Customer Referral',
+    //   value: 'Customer Referral',
+    // },
+  ],
+}
+
+export default {
+  name: 'Item picker WIP',
+  group: ['Common'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Common/Module/FieldPicker.c3.js
+++ b/src/components/Common/Module/FieldPicker.c3.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line
+import { default as component } from './FieldPicker.vue'
+
+// "TypeError: this.module.systemFields is not a function"
+const props = {
+  disableSystemFields: false,
+  module: {
+    systemFields: '',
+  },
+  fields: [],
+  disabledTypes: [],
+  systemFields: [],
+  fieldSubset: null,
+  group: 'fields',
+}
+
+export default {
+  name: 'Field picker',
+  group: ['Common', 'Module'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Common/RecordListFilter.c3.js
+++ b/src/components/Common/RecordListFilter.c3.js
@@ -1,0 +1,31 @@
+// eslint-disable-next-line
+import { default as component } from './RecordListFilter.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+const props = {
+  selectedField: { name: 'CaseNumber' },
+  namespace: new compose.Namespace(),
+  module: new compose.Module({
+    fields: [
+      {
+        isMulti: false,
+        label: 'Account Name',
+        name: 'AccountId',
+      },
+    ],
+  }),
+  recordListFilter: [{
+    groupCondition: '',
+    filter: [{
+      name: '',
+    }],
+  }],
+}
+
+export default {
+  name: 'Record list filter',
+  group: ['Common'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/ModuleFields/C3.js
+++ b/src/components/ModuleFields/C3.js
@@ -1,0 +1,2 @@
+export { default as Pagination } from './Common/Pagination.c3'
+// export { default as Configurator } from './Configurator/Configurator.c3'

--- a/src/components/ModuleFields/Common/Pagination.c3.js
+++ b/src/components/ModuleFields/Common/Pagination.c3.js
@@ -1,0 +1,34 @@
+// eslint-disable-next-line
+import { default as component } from './Pagination.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox } = components.C3.controls
+
+const props = {
+  hasPrevPage: true,
+  hasNextPage: true,
+}
+
+export default {
+  name: 'Pagination',
+  group: ['ModuleFields'],
+  component,
+  props,
+  controls: [
+    checkbox('HasPrevPage', 'hasPrevPage'),
+    checkbox('HasNextPage', 'hasNextPage'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        hasPrevPage: false,
+        hasNextPage: false,
+      },
+    },
+  ],
+}

--- a/src/components/ModuleFields/Configurator/Configurator.c3.js
+++ b/src/components/ModuleFields/Configurator/Configurator.c3.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line
+import { compose } from '@cortezaproject/corteza-js'
+import * as fieldTypes from './loader'
+
+console.error({ ...fieldTypes })
+const props = {
+  namespace: new compose.Namespace(),
+  module: new compose.Module(),
+  field: new compose.ModuleFieldBool({
+    options: {
+      trueLabel: 'true',
+      falseLabel: 'false',
+    },
+  }),
+}
+
+export default {
+  name: { ...fieldTypes },
+  group: ['ModuleFields', 'Configurator'],
+  ...fieldTypes,
+  props,
+  controls: [],
+}

--- a/src/components/ModuleFields/Editor/Bool.c3.js
+++ b/src/components/ModuleFields/Editor/Bool.c3.js
@@ -1,0 +1,46 @@
+// eslint-disable-next-line
+import { default as component } from './Bool.vue'
+import { compose } from '@cortezaproject/corteza-js'
+import * as fieldTypes from './loader'
+
+console.log(fieldTypes)
+// const namespace = ({
+//   canCreateChart: true,
+//   canCreateModule: true,
+//   canCreatePage: true,
+//   canDeleteNamespace: true,
+//   canGrant: true,
+//   canManageNamespace: true,
+//   canUpdateNamespace: true,
+//   createdAt: 'Fri Jul 30 2021 18:25:13 GMT+0300 (Eastern European Summer Time)',
+//   deletedAt: undefined,
+//   enabled: true,
+//   // labels: Object (empty),
+//   meta: {
+//     iconID: '0',
+//     logoID: '0',
+//   },
+//   name: 'CRM',
+//   namespaceID: '242313184189546499',
+//   slug: 'crm',
+// })
+
+const props = {
+  // compose.Namespace
+  namespace: new compose.Namespace(),
+  // compose.Module
+  module: new compose.Module(),
+  // compose.ModuleField
+  field: new compose.ModuleFieldBool({
+    options: { trueLabel: 'foo' },
+  }),
+  // options
+}
+
+export default {
+  name: 'Bool',
+  group: ['ModuleFields', '/Configurator'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Namespaces/C3.js
+++ b/src/components/Namespaces/C3.js
@@ -1,0 +1,3 @@
+export { default as NamespaceItem } from './NamespaceItem.c3'
+// disabled: uses store
+// export { default as NamespaceSidebar } from './NamespaceSidebar.c3'

--- a/src/components/Namespaces/NamespaceItem.c3.js
+++ b/src/components/Namespaces/NamespaceItem.c3.js
@@ -1,0 +1,50 @@
+// eslint-disable-next-line
+import { default as component } from './NamespaceItem.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox, input } = components.C3.controls
+
+const props = {
+  namespace: {
+    meta: {
+      subtitle: 'Subtitle',
+      description: 'Lorem ipsum dolor',
+    },
+    name: 'CRM',
+    enabled: true,
+    canUpdateNamespace: true,
+  },
+}
+
+export default {
+  name: 'Item',
+  group: ['Namespaces'],
+  component,
+  props,
+  controls: [
+    input('Subtitle', 'namespace.meta.subtitle'),
+    input('Description', 'namespace.meta.description'),
+    input('Name', 'namespace.name'),
+    checkbox('Enable visit namespace button', 'namespace.enabled'),
+    checkbox('Update namespace button', 'namespace.canUpdateNamespace'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        meta: {
+          subtitle: '',
+          description: '',
+        },
+        name: 'CRM',
+        enabled: false,
+        canUpdateNamespace: false,
+      },
+    },
+  ],
+}

--- a/src/components/Namespaces/NamespaceSidebar.c3.js
+++ b/src/components/Namespaces/NamespaceSidebar.c3.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line
+import { default as component } from './NamespaceSidebar.vue'
+
+// TypeError: Cannot read property 'getters' of undefined
+const props = {
+  namespaces: [
+    {
+      namespaceID: '1111111111',
+      meta: {
+        subtitle: 'Subtitle',
+        description: 'Lorem ipsum dolor',
+      },
+      name: 'CRM',
+    },
+  ],
+}
+
+export default {
+  name: 'Sidebar',
+  group: ['Namespaces'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/PageBlocks/C3.js
+++ b/src/components/PageBlocks/C3.js
@@ -1,0 +1,115 @@
+import { compose } from '@cortezaproject/corteza-js'
+import PageBlockFactory from './index.js'
+
+const options = {
+  Automation: {
+    buttons: [
+      // { enabled: true, label: 'Enabled script', script: 'someScript' },
+      { enabled: true, label: 'Enabled workflow', workflowID: '42' },
+      { enabled: false, label: 'Disabled workflow', workflowID: '42' },
+    ],
+  },
+
+  Chart: {},
+
+  Content: {
+    body: '<h1>Lorem ipsum</h1>...',
+  },
+
+  File: {
+    set: [
+      {
+        attachmentID: 'string',
+      },
+    ],
+  },
+}
+
+export const pageBlockConfigurators = Object.fromEntries([
+  // all page block kinds
+  ...compose.PageBlockRegistry.keys(),
+].map(name => {
+  const BlockClass = compose.PageBlockRegistry.get(name)
+  const block = new BlockClass({ options: (options[name] || {}) })
+  const module = new compose.Module({
+    fields: [
+      {
+        name: 'field1',
+        canUpdateRecordValue: true,
+        canReadRecordValue: true,
+      },
+    ],
+    canUpdateModule: true,
+    canDeleteModule: true,
+    canCreateRecord: true,
+    canReadRecord: true,
+    canUpdateRecord: true,
+    canDeleteRecord: true,
+    canGrant: true,
+  })
+
+  /**
+   * @todo This approach still raises errors with store, plugins and mixins
+   *       Find a way how to inject them OR rewrite components to handle
+   *       c3 environment without crashing
+   */
+  return [name + 'Configurator', {
+    name,
+    wip: true,
+    group: ['Page blocks', 'Configurator'],
+    component: PageBlockFactory,
+    controls: [],
+    props: {
+      block,
+      mode: 'configurator',
+      namespace: new compose.Namespace(),
+      module,
+      page: new compose.Page(),
+      record: new compose.Record(module),
+    },
+  }]
+}))
+
+export const pageBlockBase = Object.fromEntries([
+  // all page block kinds
+  ...compose.PageBlockRegistry.keys(),
+].map(name => {
+  const BlockClass = compose.PageBlockRegistry.get(name)
+  const block = new BlockClass({ options: (options[name] || {}) })
+  const module = new compose.Module({
+    fields: [
+      {
+        name: 'field1',
+        canUpdateRecordValue: true,
+        canReadRecordValue: true,
+      },
+    ],
+    canUpdateModule: true,
+    canDeleteModule: true,
+    canCreateRecord: true,
+    canReadRecord: true,
+    canUpdateRecord: true,
+    canDeleteRecord: true,
+    canGrant: true,
+  })
+
+  /**
+   * @todo This approach still raises errors with store, plugins and mixins
+   *       Find a way how to inject them OR rewrite components to handle
+   *       c3 environment without crashing
+   */
+  return [name, {
+    name,
+    wip: true,
+    group: ['Page blocks', 'View-mode'],
+    component: PageBlockFactory,
+    controls: [],
+    props: {
+      block,
+      namespace: new compose.Namespace(),
+      module,
+      page: new compose.Page(),
+      record: new compose.Record(module),
+    },
+  }]
+}))

--- a/src/components/PageBlocks/CalendarConfigurator/CalendarDisplay.c3.js
+++ b/src/components/PageBlocks/CalendarConfigurator/CalendarDisplay.c3.js
@@ -1,0 +1,56 @@
+// eslint-disable-next-line
+import { default as component } from './CalendarDisplay.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+const props = {
+  block: new compose.PageBlock({
+    options: {
+      header: {
+        hide: false,
+        hidePrevNext: 'true',
+        hideTitle: true,
+        hideToday: true,
+      },
+      defaultView: 'dayGridMonth',
+    },
+  }),
+  blockIndex: 7,
+  boundingRect: {},
+  mode: 'configurator',
+  module: null,
+  namespace: new compose.Namespace(),
+  page: new compose.Page(),
+  record: null,
+}
+
+export default {
+  name: 'Calendar display',
+  group: ['PageBlocks', 'Calendar configurator'],
+  component,
+  props,
+  controls: [],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        block: new compose.PageBlock({
+          options: {
+            header: {
+              hide: false,
+              hidePrevNext: 'false',
+              hideTitle: false,
+              hideToday: false,
+            },
+            defaultView: '',
+          },
+        }),
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/CalendarConfigurator/FeedSource/configs/Record.c3.js
+++ b/src/components/PageBlocks/CalendarConfigurator/FeedSource/configs/Record.c3.js
@@ -1,0 +1,75 @@
+// eslint-disable-next-line
+import { default as component } from './Record.vue'
+
+// TypeError: this.module.systemFields is not a function or its return value is not iterable
+const props = {
+  feed: {
+    options: {
+      color: '#9d5c5c',
+      moduleID: '5555555',
+      prefilter: '',
+    },
+    allDay: true,
+    endField: 'LastViewedDate',
+    startField: 'LastViewedDate',
+    titleField: 'BillingCity',
+  },
+  modules: [
+    {
+      moduleID: '242313186336833539',
+      handle: 'Pool',
+      name: 'Pool',
+      fields: [
+        { label: 'Pool', name: 'Pool', kind: 'String' },
+      ],
+    },
+    {
+      moduleID: '242313186335633539',
+      handle: 'Party',
+      name: 'Party',
+      fields: [
+        { label: 'Party', name: 'Party', kind: 'String' },
+      ],
+    },
+    {
+      moduleID: '242356786336833539',
+      handle: 'Cool',
+      name: 'Cool',
+      fields: [
+        { label: 'Cool', name: 'Cool', kind: 'String' },
+      ],
+    },
+  ],
+}
+
+export default {
+  name: 'Record',
+  group: ['PageBlocks', 'Feed Source'],
+  component,
+  props,
+  controls: [],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        feed: {
+          options: {
+            color: '#ffff',
+            moduleID: '5555555',
+            prefilter: '',
+          },
+          allDay: false,
+          endField: '',
+          startField: '',
+          titleField: '',
+        },
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/CalendarConfigurator/FeedSource/configs/Reminder.c3.js
+++ b/src/components/PageBlocks/CalendarConfigurator/FeedSource/configs/Reminder.c3.js
@@ -1,0 +1,33 @@
+// eslint-disable-next-line
+import { default as component } from './Reminder.vue'
+
+const props = {
+  feed: {
+    options: { color: '#9d5c5c' },
+  },
+  modules: [],
+}
+
+export default {
+  name: 'Reminder',
+  group: ['PageBlocks', 'Feed Source'],
+  component,
+  props,
+  controls: [],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        feed: {
+          options: { color: '#ffff' },
+        },
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/Metric/Item.c3.js
+++ b/src/components/PageBlocks/Metric/Item.c3.js
@@ -1,0 +1,52 @@
+// eslint-disable-next-line
+import { default as component } from './Item.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { input } = components.C3.controls
+
+const props = {
+  metric: {
+    valueStyle: {
+      backgroundColor: '#f6efef',
+      color: '#1d3a50',
+      fontSize: '18',
+    },
+    prefix: 'prefix',
+    suffix: 'suffix',
+  },
+  value: { value: 'value' },
+}
+
+export default {
+  name: 'Item',
+  group: ['PageBlocks', 'Metric'],
+  component,
+  props,
+  controls: [
+    input('prefix', 'metric.prefix'),
+    input('suffix', 'metric.suffix'),
+    input('value', 'value.value'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        metric: {
+          valueStyle: {
+            backgroundColor: '',
+            color: '',
+            fontSize: '',
+          },
+          prefix: '',
+          suffix: '',
+        },
+        value: { value: '' },
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/MetricConfigurator/MStyle.c3.js
+++ b/src/components/PageBlocks/MetricConfigurator/MStyle.c3.js
@@ -1,0 +1,42 @@
+// eslint-disable-next-line
+import { default as component } from './MStyle.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { input } = components.C3.controls
+
+const props = {
+  options: {
+    backgroundColor: '#f6efef',
+    color: '#1d3a44',
+    fontSize: '18',
+  },
+}
+
+export default {
+  name: 'MStyle',
+  group: ['PageBlocks', 'MetricConfigurator'],
+  component,
+  props,
+  controls: [
+    input('Background color', 'options.backgroundColor'),
+    input('Color', 'options.color'),
+    input('Font size', 'options.fontSize'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        options: {
+          backgroundColor: '',
+          color: '',
+          fontSize: '',
+        },
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/Shared/AutomationTab.c3.js
+++ b/src/components/PageBlocks/Shared/AutomationTab.c3.js
@@ -1,0 +1,62 @@
+// eslint-disable-next-line
+import { default as component } from './AutomationTab.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+// Error in render: 'TypeError: Cannot read property 'Find' of undefined
+const props = {
+  buttons: [
+    {
+      label: 'Dummy',
+      variant: 'danger',
+    },
+    {
+      button: {
+        script: null,
+      },
+    },
+  ],
+  namespace: new compose.Namespace(),
+  module: new compose.Module(),
+  field: new compose.ModuleFieldBool(),
+  boundingRect: {},
+  blockIndex: -1,
+  page: new compose.Page(),
+  block: new compose.PageBlock(),
+  // Uncaught Error: invalid module used to initialize a record
+  // record: new compose.Record(),
+  mode: '',
+}
+
+export default {
+  name: 'Automation tab WIP',
+  group: ['PageBlocks', 'Shared'],
+  component,
+  props,
+  controls: [],
+  plugins: {
+    $UIHooks: {
+      Find () { return [] },
+    },
+  },
+  // controls: [
+  //   checkbox('Done', 'done'),
+  //   checkbox('Disabled', 'disabled'),
+  //   checkbox('Small', 'small'),
+  //   input('Number of step', 'stepNumber'),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //       canGrant: false,
+  //       hasRecords: false,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/PageBlocks/Shared/AutomationTabButtonEditor.c3.js
+++ b/src/components/PageBlocks/Shared/AutomationTabButtonEditor.c3.js
@@ -1,0 +1,40 @@
+// eslint-disable-next-line
+import { default as component } from './AutomationTabButtonEditor.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { input } = components.C3.controls
+
+const props = {
+  button: {
+    label: 'Dummy',
+    variant: 'danger',
+  },
+  script: {},
+  trigger: {},
+}
+
+export default {
+  name: 'Automation editor',
+  group: ['PageBlocks', 'Shared'],
+  component,
+  props,
+  controls: [
+    input('Label', 'button.label'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        button: {
+          label: '',
+          variant: '',
+        },
+      },
+    },
+  ],
+}

--- a/src/components/PageBlocks/Wrap/Card.c3.js
+++ b/src/components/PageBlocks/Wrap/Card.c3.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line
+import { default as component } from './Card.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+const props = {
+  block: new compose.PageBlock({
+    description: '',
+    kind: 'Chart',
+    title: 'Monthly sales',
+    xywh: [4, 15, 4, 7],
+  }),
+  scrollableBody: true,
+}
+
+export default {
+  name: 'Card',
+  group: ['PageBlocks', 'Wrap'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/PageBlocks/Wrap/Plain.c3.js
+++ b/src/components/PageBlocks/Wrap/Plain.c3.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line
+import { default as component } from './Plain.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+const props = {
+  block: new compose.PageBlock(),
+  boundingRect: {},
+}
+
+export default {
+  name: 'Plain',
+  group: ['PageBlocks', 'Wrap'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/C3.js
+++ b/src/components/Public/C3.js
@@ -1,0 +1,16 @@
+// disabled: uses api plugin
+// export { default as AttachmentIndex } from './Page/Attachment/index.c3'
+// disabled: uses api plugin
+// export { default as ListLoader } from './Page/Attachment/ListLoader.c3'
+export { default as Link } from './Page/Attachment/Link.c3'
+// disabled: uses $auth plugin
+// export { default as Uploader } from './Page/Attachment/Uploader.c3'
+export { default as FieldPicker } from './Record/Exporter/FieldPicker.c3'
+// disabled: uses api plugin
+// export { default as importerIndex } from './Record/Importer/index.c3'
+// disabled: uses api plugin
+// export { default as FileUpload } from './Record/Importer/FileUpload.c3'
+export { default as FieldMatch } from './Record/Importer/FieldMatch.c3'
+export { default as ErrorReport } from './Record/Importer/ErrorReport.c3'
+// disabled: uses api plugin
+// export { default as Progress } from './Record/Importer/Progress.c3'

--- a/src/components/Public/Page/Attachment/Link.c3.js
+++ b/src/components/Public/Page/Attachment/Link.c3.js
@@ -1,0 +1,20 @@
+// eslint-disable-next-line
+import { default as component } from './Link.vue'
+
+const props = {
+  attachment: {
+    name: 'File',
+    download: 'download link',
+    meta: {
+      original: '',
+    },
+  },
+}
+
+export default {
+  name: 'Attachment link',
+  group: ['Public'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/Page/Attachment/ListLoader.c3.js
+++ b/src/components/Public/Page/Attachment/ListLoader.c3.js
@@ -1,0 +1,25 @@
+// eslint-disable-next-line
+import { default as component } from './ListLoader.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+// TypeError: Cannot read property 'attachmentRead' of undefined
+const props = {
+  enableDelete: true,
+  enableOrder: true,
+  namespace: new compose.Namespace({
+    namespaceID: '',
+    attachmentID: '',
+  }),
+  kind: 'page',
+  mode: 'list',
+  set: ['244165968555671554'],
+  hideFileName: false,
+}
+
+export default {
+  name: 'List loader WIP',
+  group: ['Public', 'Attachment'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/Page/Attachment/Uploader.c3.js
+++ b/src/components/Public/Page/Attachment/Uploader.c3.js
@@ -1,0 +1,41 @@
+// eslint-disable-next-line
+import { default as component } from './Uploader.vue'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+// Cannot read property 'accessToken' of undefined
+const props = {
+  endpoint: 'Endpoint',
+  acceptedFiles: [],
+  maxFilesize: 50,
+  label: 'Label',
+}
+
+export default {
+  name: 'Attachment uploader WIP',
+  group: ['Public'],
+  component,
+  props,
+  controls: [],
+  // controls: [
+  //   checkbox('Done', 'done'),
+  //   checkbox('Disabled', 'disabled'),
+  //   checkbox('Small', 'small'),
+  //   input('Number of step', 'stepNumber'),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //       canGrant: false,
+  //       hasRecords: false,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/Public/Page/Attachment/index.c3.js
+++ b/src/components/Public/Page/Attachment/index.c3.js
@@ -1,0 +1,46 @@
+// eslint-disable-next-line
+import { default as component } from './index.vue'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+// Property or method "isImage" is not defined on the instance but referenced during render
+const props = {
+  kind: '',
+  mode: 'list',
+  value: {
+    download: 'dfs',
+    name: 'ss',
+    size: 32,
+    changedAt: 'dfc',
+    previewUrl: 'fsdfs',
+  },
+}
+
+export default {
+  name: 'Index WIP',
+  group: ['Public', 'Attachment'],
+  component,
+  props,
+  controls: [],
+  // controls: [
+  //   checkbox('Done', 'done'),
+  //   checkbox('Disabled', 'disabled'),
+  //   checkbox('Small', 'small'),
+  //   input('Number of step', 'stepNumber'),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //       canGrant: false,
+  //       hasRecords: false,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/Public/Record/Exporter/FieldPicker.c3.js
+++ b/src/components/Public/Record/Exporter/FieldPicker.c3.js
@@ -1,0 +1,29 @@
+// eslint-disable-next-line
+import { default as component } from './FieldPicker.vue'
+import { compose } from '@cortezaproject/corteza-js'
+
+// TypeError: this.module.systemFields is not a function"
+const props = {
+  allowJSON: true,
+  allowCSV: true,
+  module: new compose.Module(),
+  preselectedFields: [],
+  recordCount: 0,
+  query: undefined,
+  selection: [],
+  filterRangeType: 'all',
+  filterRangeBy: 'created_at',
+  dateRange: 'lastMonth',
+  startDate: null,
+  endDate: null,
+  systemFields: ['ownedBy', 'createdAt', 'createdBy', 'updatedAt', 'updatedBy'],
+  disabledTypes: ['User', 'Record', 'File'],
+}
+
+export default {
+  name: 'Field picker',
+  group: ['Page Record'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/Record/Importer/ErrorReport.c3.js
+++ b/src/components/Public/Record/Importer/ErrorReport.c3.js
@@ -1,0 +1,33 @@
+// eslint-disable-next-line
+import { default as component } from './ErrorReport.vue'
+
+const props = {
+  session: {
+    fields: {},
+    progress: {
+      completed: 0,
+      entryCount: 37080,
+      failLog: {
+        errors: {
+          'empty field Company': 1,
+          'empty field LastName': 1,
+          'invalidValue field Country': 1,
+          'invalidValue value Level 1': 1,
+        },
+      },
+      failReason: 'failed to complete transaction: store encoder encode corteza::compose:record [242313185917403139]: 3 issue(s) found',
+      failed: 1,
+      finishedAt: '2021-08-12T13:13:20.1322898Z',
+      startedAt: '2021-08-12T13:13:18.6814197Z',
+    },
+  },
+  noPool: false,
+}
+
+export default {
+  name: 'Error report',
+  group: ['Public/Record'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/Record/Importer/FieldMatch.c3.js
+++ b/src/components/Public/Record/Importer/FieldMatch.c3.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line
+import { default as component } from './FieldMatch.vue'
+
+const props = {
+  session: {
+    fields: {
+      Test1: '',
+      Test2: '',
+      Test3: '',
+    },
+  },
+  module: {
+    fields: [
+      {
+        label: 'Address Street',
+        name: 'Street',
+      },
+      {
+        label: 'Address City',
+        name: 'Street',
+      },
+      {
+        label: 'Party',
+        name: 'Street',
+      },
+    ],
+  },
+}
+
+export default {
+  name: 'Field match',
+  group: ['Public/Record'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/components/Public/Record/Importer/FileUpload.c3.js
+++ b/src/components/Public/Record/Importer/FileUpload.c3.js
@@ -1,0 +1,39 @@
+// eslint-disable-next-line
+import { default as component } from './FileUpload.vue'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+// "TypeError: Cannot read property 'recordImportInitEndpoint' of undefined
+const props = {
+  namespace: {},
+  module: {},
+}
+
+export default {
+  name: 'File upload WIP',
+  group: ['Public Record'],
+  component,
+  props,
+  controls: [],
+  // controls: [
+  //   checkbox('Done', 'done'),
+  //   checkbox('Disabled', 'disabled'),
+  //   checkbox('Small', 'small'),
+  //   input('Number of step', 'stepNumber'),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //       canGrant: false,
+  //       hasRecords: false,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/Public/Record/Importer/Progress.c3.js
+++ b/src/components/Public/Record/Importer/Progress.c3.js
@@ -1,0 +1,41 @@
+// eslint-disable-next-line
+import { default as component } from './Progress.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { checkbox } = components.C3.controls
+
+// when !noPool => TypeError: Cannot read property 'recordImportProgress' of undefined
+const props = {
+  session: {
+    progress: {
+      completed: 0,
+      entryCount: 1,
+      failed: 0,
+      finishedAt: null,
+    },
+  },
+  noPool: false,
+}
+
+export default {
+  name: 'Progress WIP',
+  group: ['Public', 'Record'],
+  component,
+  props,
+  controls: [
+    checkbox('No pool', 'noPool'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        noPool: false,
+      },
+    },
+  ],
+}

--- a/src/components/Public/Record/Importer/index.c3.js
+++ b/src/components/Public/Record/Importer/index.c3.js
@@ -1,0 +1,39 @@
+// eslint-disable-next-line
+import { default as component } from './index.vue'
+// import { components } from '@cortezaproject/corteza-vue'
+// const { checkbox, input } = components.C3.controls
+
+// "TypeError: Cannot read property 'recordImportInitEndpoint' of undefined
+const props = {
+  namespace: {},
+  module: { name: 'Test module' },
+}
+
+export default {
+  name: 'Importer WIP',
+  group: ['Public Record'],
+  component,
+  props,
+  controls: [],
+  // controls: [
+  //   checkbox('Done', 'done'),
+  //   checkbox('Disabled', 'disabled'),
+  //   checkbox('Small', 'small'),
+  //   input('Number of step', 'stepNumber'),
+  // ],
+
+  // scenarios: [
+  //   {
+  //     label: 'Full form',
+  //     props,
+  //   },
+  //   {
+  //     label: 'Empty form',
+  //     props: {
+  //       ...props,
+  //       canGrant: false,
+  //       hasRecords: false,
+  //     },
+  //   },
+  // ],
+}

--- a/src/components/RightPanel/C3.js
+++ b/src/components/RightPanel/C3.js
@@ -1,0 +1,2 @@
+export { default as List } from './reminder/List.c3'
+export { default as Edit } from './reminder/Edit.c3'

--- a/src/components/RightPanel/reminder/Edit.c3.js
+++ b/src/components/RightPanel/reminder/Edit.c3.js
@@ -1,0 +1,45 @@
+// eslint-disable-next-line
+import { default as component } from './Edit.vue'
+import { components } from '@cortezaproject/corteza-vue'
+const { input } = components.C3.controls
+
+const props = {
+  edit: {
+    payload: {
+      title: 'Reminder',
+      notes: 'Urgent!',
+    },
+  },
+  myID: '242313586825756675',
+  users: [],
+}
+
+export default {
+  name: 'Edit reminder',
+  group: ['Right Panel'],
+  component,
+  props,
+  controls: [
+    input('Title', 'edit.payload.title'),
+    input('Notes', 'edit.payload.notes'),
+  ],
+
+  scenarios: [
+    {
+      label: 'Full form',
+      props,
+    },
+    {
+      label: 'Empty form',
+      props: {
+        ...props,
+        edit: {
+          payload: {
+            title: '',
+            notes: '',
+          },
+        },
+      },
+    },
+  ],
+}

--- a/src/components/RightPanel/reminder/List.c3.js
+++ b/src/components/RightPanel/reminder/List.c3.js
@@ -1,0 +1,26 @@
+// eslint-disable-next-line
+import { default as component } from './List.vue'
+
+const props = {
+  namespaceID: '242313184189546499',
+  reminders: [
+    {
+      payload: {
+        notes: 'Urgent!',
+        remindAt: 1800000,
+        title: 'Remind me',
+      },
+      remindAt: 'Thu Aug 12 2021 13:09:40 GMT+0300 (Eastern European Summer Time)',
+      reminderID: '244162818700476418',
+      snoozeCount: 0,
+    },
+  ],
+}
+
+export default {
+  name: 'List reminder',
+  group: ['Right Panel'],
+  component,
+  props,
+  controls: [],
+}

--- a/src/dev-env.js
+++ b/src/dev-env.js
@@ -1,0 +1,32 @@
+import Vue from 'vue'
+import Router from 'vue-router'
+import BootstrapVue from 'bootstrap-vue'
+import i18n from './i18n'
+import c3catalogue from './components/C3'
+import { components } from '@cortezaproject/corteza-vue'
+import './components'
+import './themes'
+
+const routes = [
+  {
+    path: '/c3',
+    name: 'c3',
+    component: components.C3.View,
+    props: { catalogue: c3catalogue },
+  },
+  { path: '*', redirect: { name: 'c3' } },
+]
+
+Vue.use(Router)
+Vue.use(BootstrapVue)
+
+export default new Vue({
+  el: '#app',
+  name: 'DevEnv',
+  template: '<router-view/>',
+  router: new Router({
+    mode: 'history',
+    routes,
+  }),
+  i18n: i18n(),
+})


### PR DESCRIPTION
Every c3 definition which contains 'WIP' in its name throws an error. I've described the error in the file itself.

Here are the five types of errors:
1. 'Cannot read property 'Find' of undefined' in AutomationTab
2. 'Cannot read property 'getters' of undefined at VueComponent.mappedGetter' in Admin/Pages/Tree, NamespaceSidebar, MetricConfigurator/index
3. 'TypeError: this.module.systemFields is not a function' in both FieldPicker(s) in Module and Exporter, RecordListFilter, FeedSource/Record
4. Lost value in Configurator (more in the component)
5. Cannot read property 'attachmentRead' of undefined in ListLoader

Files which don't have a C3 definition:
- all files in ModuleFields/Configurator, ModuleFields/Editor, ModuleFields/Viewer **
- root elements in PageBlocks **
- Common/ItemPicker because it uses slots


** c3 files can be easily created with the help of a function which iterates through all of the fields/pageBLocks and passes props to them