### PR TITLE
Fixing .popover to zIndex 999

### DIFF
--- a/src/themes/corteza-base/custom.scss
+++ b/src/themes/corteza-base/custom.scss
@@ -262,3 +262,7 @@ input[type="search"]::-webkit-search-cancel-button {
     margin-top: 0.25rem;
   }
 }
+
+.popover {
+  z-index: 999;
+}


### PR DESCRIPTION
Actual .popover zIndex is too high for column filters if we have a dropdown initialized in it (ex: with a column set as RecordSelector or Dropdown).
```css
.popover { z-index: 1060 }
.vs__dropdown-menu { z-index: 1000 }
```

![nHmyTzRua5](https://user-images.githubusercontent.com/86595459/137318852-0bd62536-4535-4dad-838f-3954aa230de2.gif)


**This might not be the best way to fix it!** Please investigate on your side and decide what is the best way to fix it 😄 .

Best regards