### PR TITLE
Move wrongly placed errors tag next to vue-select

### DIFF
--- a/src/components/ModuleFields/Editor/User.vue
+++ b/src/components/ModuleFields/Editor/User.vue
@@ -82,6 +82,7 @@
             @next="goToPage(true)"
           />
         </vue-select>
+        <errors :errors="errors" />
       </template>
       <template v-slot:default="ctx">
         <vue-select
@@ -110,8 +111,8 @@
           />
         </vue-select>
         <span v-else>{{ getOptionLabel(getUserByIndex(ctx.index)) }}</span>
+        <errors :errors="errors" />
       </template>
-      <errors :errors="errors" />
     </multi>
     <template
       v-else


### PR DESCRIPTION
Hello

This is needed to fix the same issue as my previous PR about "error message" but this time for User Selector.

N.B.: The same issue happen for the error being displayed next to each added line after a failed save attempt (like explained in previous PR).