### PR TITLE
Provide record context to attachment upload

### DIFF
--- a/src/components/ModuleFields/Editor/File.vue
+++ b/src/components/ModuleFields/Editor/File.vue
@@ -32,6 +32,7 @@
       :endpoint="endpoint"
       :accepted-files="mimetypes"
       :max-filesize="maxSize"
+      :form-data="uploaderFormData"
       @uploaded="appendAttachment"
     />
 
@@ -51,6 +52,7 @@
 import base from './base'
 import Uploader from 'corteza-webapp-compose/src/components/Public/Page/Attachment/Uploader'
 import ListLoader from 'corteza-webapp-compose/src/components/Public/Page/Attachment/ListLoader'
+import { NoID } from '@cortezaproject/corteza-js'
 
 export default {
   components: {
@@ -71,6 +73,18 @@ export default {
         recordID,
         fieldName: this.field.name,
       })
+    },
+
+    uploaderFormData () {
+      const fd = {
+        fieldName: this.field.name,
+      }
+
+      if (this.record && this.record.recordID !== NoID) {
+        fd.recordID = this.record.recordID
+      }
+
+      return fd
     },
 
     mimetypes () {

--- a/src/components/Public/Page/Attachment/Uploader.vue
+++ b/src/components/Public/Page/Attachment/Uploader.vue
@@ -76,6 +76,11 @@ export default {
       type: String,
       default: null,
     },
+    formData: {
+      type: Object,
+      required: false,
+      default: () => ({}),
+    },
   },
 
   data () {
@@ -92,6 +97,8 @@ export default {
     },
 
     dzOptions () {
+      const vm = this
+
       return {
         paramName: 'upload',
         maxFilesize: this.maxFilesize, // mb
@@ -106,6 +113,13 @@ export default {
         uploadMultiple: false,
         parallelUploads: 1,
         acceptedFiles: null,
+        init: function () {
+          this.on('sending', function (file, xhr, formData) {
+            for (const k in vm.formData || {}) {
+              formData.append(k, vm.formData[k])
+            }
+          })
+        },
         headers: {
           // https://github.com/enyo/dropzone/issues/1154
           'Cache-Control': '',


### PR DESCRIPTION
We need to push some extra params to the back-end when uploading attachments.