### PR TITLE
Ensure canvas exists before creating the renderer

### DIFF
--- a/src/components/Chart/index.vue
+++ b/src/components/Chart/index.vue
@@ -75,11 +75,14 @@ export default {
         }
         const type = chart.baseChartType(data.datasets)
 
-        const newRenderer = () => new ChartJS(this.$refs.chartCanvas.getContext('2d'), { options, plugins: [...plugins, Funnel, Gauge, csc], data, type })
-        if (this.renderer) {
-          this.renderer.destroy()
+        const canvas = this.$refs.chartCanvas || undefined
+        if (canvas) {
+          const newRenderer = () => new ChartJS(canvas.getContext('2d'), { options, plugins: [...plugins, Funnel, Gauge, csc, ChartjsChartMatrix], data, type })
+          if (this.renderer) {
+            this.renderer.destroy()
+          }
+          this.renderer = newRenderer()
         }
-        this.renderer = newRenderer()
       } catch (e) {
         this.toastErrorHandler(this.$t('chart.optionsBuildFailed'))(e)
       }


### PR DESCRIPTION
If you navigate from a heavy page containing a charts that didn't begin his render to another page you got the following error : 
 __Cannot read properties of undefined (reading 'getContext')__

The error is throw because when navigating to another page the canvas don't exist anymore but the chart are still being rendered.

This PR propose to not try rendering a chart if the canvas doesn't exist, that way we can pursue the navigation without error.

Bug example:
![getContext](https://user-images.githubusercontent.com/82505474/146941477-2f310a0b-0954-4c5a-9d15-69612997bd3a.gif)
_here we can see that when we go back to the "Empty" page half of the chart are still blank because their rendering didn't start_
