### PR TITLE
2023.3.x feature open record in modal

### DIFF
--- a/src/components/Common/RecordToolbar.vue
+++ b/src/components/Common/RecordToolbar.vue
@@ -1,7 +1,8 @@
 <template>
   <b-container
     fluid
-    class="bg-white shadow border-top p-3"
+    :class="{'shadow border-top': !showRecordModal}"
+    class="bg-white p-3"
   >
     <b-row
       no-gutters
@@ -19,10 +20,16 @@
           @click.prevent="$emit('back')"
         >
           <font-awesome-icon
+            v-if="!showRecordModal"
             :icon="['fas', 'chevron-left']"
             class="back-icon"
           />
-          {{ labels.back || $t('label.back') }}
+          <font-awesome-icon
+            v-else
+            :icon="['fa', 'times']"
+            class="back-icon"
+          />
+          {{ showRecordModal ? $t('label.close') : labels.back || $t('label.back') }}
         </b-button>
       </div>
 
@@ -172,6 +179,11 @@ export default {
     isDeleted: {
       type: Boolean,
       default: true,
+    },
+
+    showRecordModal: {
+      type: Boolean,
+      required: false,
     },
   },
 

--- a/src/components/PageBlocks/RecordListBase.vue
+++ b/src/components/PageBlocks/RecordListBase.vue
@@ -574,6 +574,14 @@
           </b-col>
         </b-row>
       </b-container>
+      <b-modal
+        v-model="showRecordModal"
+        title="BootstrapVue"
+      >
+        <p class="my-4">
+          Hello from modal!
+        </p>
+      </b-modal>
     </template>
   </wrap>
 </template>
@@ -594,6 +602,9 @@ import { components, url } from '@cortezaproject/corteza-vue'
 import draggable from 'vuedraggable'
 import RecordListFilter from 'corteza-webapp-compose/src/components/Common/RecordListFilter'
 import ColumnPicker from 'corteza-webapp-compose/src/components/Admin/Module/Records/ColumnPicker'
+import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
+import ViewRecord from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
+
 const { CInputSearch } = components
 
 export default {
@@ -611,6 +622,8 @@ export default {
     RecordListFilter,
     ColumnPicker,
     CInputSearch,
+    Grid,
+    ViewRecord,
   },
 
   extends: base,
@@ -666,6 +679,8 @@ export default {
       items: [],
       idPrefix: `rl:${this.blockIndex}`,
       recordListFilter: [],
+
+      showRecordModal: false,
     }
   },
 
@@ -1149,9 +1164,17 @@ export default {
         },
         query: null,
       }
+      /* old logic - to be deleted */
+      // if (this.options.openInNewTab) {
+      //   window.open(this.$router.resolve(route).href)
+      // } else {
+      //   this.$router.push(route)
+      // }
 
-      if (this.options.openInNewTab) {
+      if (this.options.recordDisplayOption === 'newTab') {
         window.open(this.$router.resolve(route).href)
+      } else if (this.options.recordDisplayOption === 'modal') {
+        this.showRecordModal = true
       } else {
         this.$router.push(route)
       }

--- a/src/components/PageBlocks/RecordListBase.vue
+++ b/src/components/PageBlocks/RecordListBase.vue
@@ -667,8 +667,6 @@ export default {
       items: [],
       idPrefix: `rl:${this.blockIndex}`,
       recordListFilter: [],
-
-      showRecordModal: false,
     }
   },
 
@@ -1156,12 +1154,10 @@ export default {
       if (this.options.recordDisplayOption === 'newTab') {
         window.open(this.$router.resolve(route).href)
       } else if (this.options.recordDisplayOption === 'modal') {
-        this.showRecordModal = true
-        this.$root.$emit('showRecordModal', {
+        this.$root.$emit('show-record-modal', {
           moduleID: this.recordListModule.moduleID,
           recordPageID: this.recordPageID,
           recordID,
-          showRecordModal: this.showRecordModal,
         })
       } else {
         this.$router.push(route)

--- a/src/components/PageBlocks/RecordListBase.vue
+++ b/src/components/PageBlocks/RecordListBase.vue
@@ -574,14 +574,6 @@
           </b-col>
         </b-row>
       </b-container>
-      <b-modal
-        v-model="showRecordModal"
-        title="BootstrapVue"
-      >
-        <p class="my-4">
-          Hello from modal!
-        </p>
-      </b-modal>
     </template>
   </wrap>
 </template>
@@ -602,8 +594,6 @@ import { components, url } from '@cortezaproject/corteza-vue'
 import draggable from 'vuedraggable'
 import RecordListFilter from 'corteza-webapp-compose/src/components/Common/RecordListFilter'
 import ColumnPicker from 'corteza-webapp-compose/src/components/Admin/Module/Records/ColumnPicker'
-import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
-import ViewRecord from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
 
 const { CInputSearch } = components
 
@@ -622,8 +612,6 @@ export default {
     RecordListFilter,
     ColumnPicker,
     CInputSearch,
-    Grid,
-    ViewRecord,
   },
 
   extends: base,
@@ -1164,17 +1152,17 @@ export default {
         },
         query: null,
       }
-      /* old logic - to be deleted */
-      // if (this.options.openInNewTab) {
-      //   window.open(this.$router.resolve(route).href)
-      // } else {
-      //   this.$router.push(route)
-      // }
 
       if (this.options.recordDisplayOption === 'newTab') {
         window.open(this.$router.resolve(route).href)
       } else if (this.options.recordDisplayOption === 'modal') {
         this.showRecordModal = true
+        this.$root.$emit('showRecordModal', {
+          moduleID: this.recordListModule.moduleID,
+          recordPageID: this.recordPageID,
+          recordID,
+          showRecordModal: this.showRecordModal,
+        })
       } else {
         this.$router.push(route)
       }

--- a/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/src/components/PageBlocks/RecordListConfigurator.vue
@@ -250,12 +250,36 @@
         <b-form-checkbox v-model="options.selectable">
           {{ $t('recordList.selectable') }}
         </b-form-checkbox>
-        <b-form-checkbox
+        <!--Old logic - to be deleted -->
+        <!-- <b-form-checkbox
           v-model="options.openInNewTab"
         >
           {{ $t('recordList.record.openInNewTab') }}
-        </b-form-checkbox>
+        </b-form-checkbox> -->
       </b-form-group>
+
+      <!--Select options how to open a record-->
+      <b-form-group
+        :label="$t('recordList.record.recordDisplayOptions')"
+        :label-cols="3"
+        breakpoint="md"
+        horizontal
+      >
+        <b-form-select
+          v-model="options.recordDisplayOption"
+          :options="recordDisplayOptions"
+          required
+        >
+          <template slot="first">
+            <option
+              :value="0"
+            >
+              {{ $t('recordList.record.openInSameTab') }}
+            </option>
+          </template>
+        </b-form-select>
+      </b-form-group>
+
       <b-form-group
         horizontal
         :label-cols="3"
@@ -323,6 +347,13 @@ export default {
       modules: 'module/set',
       pages: 'page/set',
     }),
+
+    recordDisplayOptions () {
+      return [
+        { value: 'newTab', text: this.$t('recordList.record.openInNewTab') },
+        { value: 'modal', text: this.$t('recordList.record.openInModal') },
+      ]
+    },
 
     moduleOptions () {
       return [

--- a/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/src/components/PageBlocks/RecordListConfigurator.vue
@@ -250,12 +250,6 @@
         <b-form-checkbox v-model="options.selectable">
           {{ $t('recordList.selectable') }}
         </b-form-checkbox>
-        <!--Old logic - to be deleted -->
-        <!-- <b-form-checkbox
-          v-model="options.openInNewTab"
-        >
-          {{ $t('recordList.record.openInNewTab') }}
-        </b-form-checkbox> -->
       </b-form-group>
 
       <!--Select options how to open a record-->
@@ -269,15 +263,7 @@
           v-model="options.recordDisplayOption"
           :options="recordDisplayOptions"
           required
-        >
-          <template slot="first">
-            <option
-              :value="0"
-            >
-              {{ $t('recordList.record.openInSameTab') }}
-            </option>
-          </template>
-        </b-form-select>
+        />
       </b-form-group>
 
       <b-form-group
@@ -350,6 +336,7 @@ export default {
 
     recordDisplayOptions () {
       return [
+        { value: 'sameTab', text: this.$t('recordList.record.openInSameTab') },
         { value: 'newTab', text: this.$t('recordList.record.openInNewTab') },
         { value: 'modal', text: this.$t('recordList.record.openInModal') },
       ]

--- a/src/components/PageBlocks/RecordListConfigurator.vue
+++ b/src/components/PageBlocks/RecordListConfigurator.vue
@@ -262,7 +262,6 @@
         <b-form-select
           v-model="options.recordDisplayOption"
           :options="recordDisplayOptions"
-          required
         />
       </b-form-group>
 

--- a/src/components/Public/Record/Modal.vue
+++ b/src/components/Public/Record/Modal.vue
@@ -2,11 +2,12 @@
   <b-modal
     id="record-modal"
     v-model="showRecordModal"
+    scrollable
     body-class="p-0"
     size="xl"
   >
     <template #modal-title>
-      <portal-target name="record-modal-header" />
+      {{ pageTitle }}
     </template>
     <view-record
       :namespace="namespace"
@@ -16,14 +17,17 @@
       :show-record-modal="showRecordModal"
     />
     <template #modal-footer>
-      <portal-target name="record-modal-footer" />
+      <portal-target
+        class="w-100"
+        name="record-modal-footer"
+      />
     </template>
   </b-modal>
 </template>
 
 <script>
 import record from 'corteza-webapp-compose/src/mixins/record'
-import { compose } from '@cortezaproject/corteza-js'
+import { compose, NoID } from '@cortezaproject/corteza-js'
 import ViewRecord from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
 import { mapGetters } from 'vuex'
 
@@ -63,26 +67,32 @@ export default {
       getModuleByID: 'module/getByID',
       pages: 'page/set',
     }),
+
+    pageTitle () {
+      if (this.page.pageID !== NoID) {
+        const { title = '', handle = '' } = this.page
+        return title || handle || this.$t('navigation:noPageTitle')
+      }
+
+      return ''
+    },
   },
 
   created () {
-    this.$root.$on('showRecordModal', this.showModal)
+    this.$root.$on('show-record-modal', this.showModal)
   },
 
   beforeDestroy () {
-    this.$root.$off('showRecordModal', this.showModal)
+    this.$root.$off('show-record-modal')
   },
 
   methods: {
     showModal (e) {
-      const { recordID, moduleID, recordPageID, showRecordModal } = e
-      if (showRecordModal) {
-        this.showRecordModal = true
-        this.recordID = recordID
-        this.module = module
-        this.page = this.pages.find(p => p.pageID === recordPageID)
-        this.module = this.getModuleByID(moduleID)
-      }
+      const { recordID, moduleID, recordPageID } = e
+      this.showRecordModal = true
+      this.recordID = recordID
+      this.page = this.pages.find(p => p.pageID === recordPageID)
+      this.module = this.getModuleByID(moduleID)
     },
   },
 }
@@ -92,6 +102,7 @@ export default {
 <style>
 #record-modal .modal-dialog {
   height: 100%;
+  max-width: 85vw;
 }
 
 #record-modal .modal-content {

--- a/src/components/Public/Record/Modal.vue
+++ b/src/components/Public/Record/Modal.vue
@@ -1,0 +1,100 @@
+<template>
+  <b-modal
+    id="record-modal"
+    v-model="showRecordModal"
+    body-class="p-0"
+    size="xl"
+  >
+    <template #modal-title>
+      <portal-target name="record-modal-header" />
+    </template>
+    <view-record
+      :namespace="namespace"
+      :page="page"
+      :module="module"
+      :record-i-d="recordID"
+      :show-record-modal="showRecordModal"
+    />
+    <template #modal-footer>
+      <portal-target name="record-modal-footer" />
+    </template>
+  </b-modal>
+</template>
+
+<script>
+import record from 'corteza-webapp-compose/src/mixins/record'
+import { compose } from '@cortezaproject/corteza-js'
+import ViewRecord from 'corteza-webapp-compose/src/views/Public/Pages/Records/View'
+import { mapGetters } from 'vuex'
+
+export default {
+  i18nOptions: {
+    namespaces: 'block',
+  },
+
+  name: 'RecordModal',
+
+  components: {
+    ViewRecord,
+  },
+
+  mixins: [
+    record,
+  ],
+
+  props: {
+    namespace: {
+      type: compose.Namespace,
+      required: true,
+    },
+  },
+
+  data () {
+    return {
+      showRecordModal: false,
+      recordID: null,
+      module: null,
+      page: null,
+    }
+  },
+
+  computed: {
+    ...mapGetters({
+      getModuleByID: 'module/getByID',
+      pages: 'page/set',
+    }),
+  },
+
+  created () {
+    this.$root.$on('showRecordModal', this.showModal)
+  },
+
+  beforeDestroy () {
+    this.$root.$off('showRecordModal', this.showModal)
+  },
+
+  methods: {
+    showModal (e) {
+      const { recordID, moduleID, recordPageID, showRecordModal } = e
+      if (showRecordModal) {
+        this.showRecordModal = true
+        this.recordID = recordID
+        this.module = module
+        this.page = this.pages.find(p => p.pageID === recordPageID)
+        this.module = this.getModuleByID(moduleID)
+      }
+    },
+  },
+}
+
+</script>
+
+<style>
+#record-modal .modal-dialog {
+  height: 100%;
+}
+
+#record-modal .modal-content {
+  height: 100%;
+}
+</style>

--- a/src/components/Public/Record/Modal.vue
+++ b/src/components/Public/Record/Modal.vue
@@ -9,6 +9,7 @@
     <template #modal-title>
       {{ pageTitle }}
     </template>
+
     <view-record
       :namespace="namespace"
       :page="page"
@@ -16,10 +17,11 @@
       :record-i-d="recordID"
       :show-record-modal="showRecordModal"
     />
+
     <template #modal-footer>
       <portal-target
-        class="w-100"
         name="record-modal-footer"
+        class="w-100 m-0"
       />
     </template>
   </b-modal>
@@ -102,7 +104,7 @@ export default {
 <style>
 #record-modal .modal-dialog {
   height: 100%;
-  max-width: 85vw;
+  max-width: 90vw;
 }
 
 #record-modal .modal-content {

--- a/src/components/Public/Record/Modal.vue
+++ b/src/components/Public/Record/Modal.vue
@@ -4,10 +4,13 @@
     v-model="showRecordModal"
     scrollable
     body-class="p-0"
+    footer-class="p-0"
     size="xl"
   >
     <template #modal-title>
-      {{ pageTitle }}
+      <portal-target
+        name="record-modal-header"
+      />
     </template>
 
     <view-record

--- a/src/mixins/record.js
+++ b/src/mixins/record.js
@@ -154,7 +154,12 @@ export default {
           if (this.record.valueErrors.set) {
             this.toastWarning(this.$t('notification:record.validationWarnings'))
           } else {
-            this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
+            if (this.showRecordModal) {
+              this.inEditing = false
+              this.inCreating = false
+            } else {
+              this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
+            }
           }
         })
         .catch(this.toastErrorHandler(this.$t(

--- a/src/mixins/record.js
+++ b/src/mixins/record.js
@@ -153,13 +153,11 @@ export default {
         .then(() => {
           if (this.record.valueErrors.set) {
             this.toastWarning(this.$t('notification:record.validationWarnings'))
+          } else if (this.showRecordModal) {
+            this.inEditing = false
+            this.inCreating = false
           } else {
-            if (this.showRecordModal) {
-              this.inEditing = false
-              this.inCreating = false
-            } else {
-              this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
-            }
+            this.$router.push({ name: route, params: { ...this.$route.params, recordID: this.record.recordID } })
           }
         })
         .catch(this.toastErrorHandler(this.$t(

--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -11,6 +11,12 @@
       {{ $t('record.recordDeleted') }}
     </b-alert>
 
+    <portal
+      :to="portalTopbarTitle"
+    >
+      {{ title }}
+    </portal>
+
     <grid
       v-bind="$props"
       :errors="errors"
@@ -20,7 +26,7 @@
     />
 
     <portal
-      :to="recordToolbar"
+      :to="portalRecordToolbar"
     >
       <record-toolbar
         :module="module"
@@ -100,11 +106,15 @@ export default {
     return {
       inEditing: false,
       inCreating: false,
+      titlePreffix: 'view', // dynamic i18n variable to show correct record title based on different actions
     }
   },
 
   computed: {
-    recordToolbar () {
+    portalTopbarTitle () {
+      return this.showRecordModal ? 'record-modal-header' : 'topbar-title'
+    },
+    portalRecordToolbar () {
       return this.showRecordModal ? 'record-modal-footer' : 'toolbar'
     },
 
@@ -130,7 +140,7 @@ export default {
 
     title () {
       const { name, handle } = this.module
-      return this.$t('page:public.record.view.title', { name: name || handle, interpolation: { escapeValue: false } })
+      return this.$t(`page:public.record.${this.titlePreffix}.title`, { name: name || handle, interpolation: { escapeValue: false } })
     },
   },
 
@@ -207,6 +217,7 @@ export default {
       if (this.showRecordModal) {
         this.inEditing = true
         this.inCreating = true
+        this.titlePreffix = 'create'
         this.record = new compose.Record(this.module, { values: this.values })
       } else {
         this.$router.push({ name: 'page.record.create', params: this.newRouteParams })
@@ -226,10 +237,11 @@ export default {
     handleEdit () {
       if (this.showRecordModal) {
         this.inCreating = false
+        this.inEditing = true
+        this.titlePreffix = 'edit'
       } else {
         this.$router.push({ name: 'page.record.edit', params: this.$route.params })
       }
-      this.inEditing = true
     },
   },
 }

--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{'flex-column': showRecordModal}"
+    :class="{ 'flex-column': showRecordModal }"
     class="d-flex flex-grow-1 w-100 h-100"
   >
     <b-alert
@@ -20,11 +20,9 @@
     />
 
     <portal
-      class="w-100"
       :to="recordToolbar"
     >
       <record-toolbar
-        :show-record-modal="showRecordModal"
         :module="module"
         :record="record"
         :labels="recordToolbarLabels"
@@ -35,6 +33,7 @@
         :in-editing="inEditing"
         :hide-clone="inCreating"
         :hide-add="inCreating"
+        :show-record-modal="showRecordModal"
         @add="handleAdd()"
         @clone="handleClone()"
         @edit="handleEdit()"
@@ -90,7 +89,7 @@ export default {
       required: false,
       default: '',
     },
-
+    // Open record in a modal
     showRecordModal: {
       type: Boolean,
       required: false,

--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-grow-1 w-100">
+  <div class="d-flex flex-grow-1 w-100 h-100">
     <b-alert
       v-if="isDeleted"
       show
@@ -20,7 +20,34 @@
       @reload="loadRecord()"
     />
 
-    <portal to="toolbar">
+    <portal
+      v-if="showRecordModal"
+      to="record-modal-footer"
+    >
+      <record-toolbar
+        :module="module"
+        :record="record"
+        :labels="recordToolbarLabels"
+        :processing="processing"
+        :processing-submit="processingSubmit"
+        :processing-delete="processingDelete"
+        :is-deleted="isDeleted"
+        :in-editing="inEditing"
+        :hide-clone="inCreating"
+        :hide-add="inCreating"
+        @add="handleAdd()"
+        @clone="handleClone()"
+        @edit="handleEdit()"
+        @delete="handleDelete()"
+        @back="handleBack()"
+        @submit="handleFormSubmit('page.record')"
+      />
+    </portal>
+
+    <portal
+      v-else
+      to="toolbar"
+    >
       <record-toolbar
         :module="module"
         :record="record"
@@ -86,6 +113,11 @@ export default {
       type: String,
       required: false,
       default: '',
+    },
+
+    showRecordModal: {
+      type: Boolean,
+      required: false,
     },
   },
 
@@ -183,11 +215,21 @@ export default {
        * Not the best way since we can not always know where we
        * came from (and "were" is back).
        */
-      this.$router.back()
+      if (this.showRecordModal) {
+        this.inEditing = false
+        this.inCreating = false
+      } else {
+        this.$router.back()
+      }
     },
 
     handleAdd () {
-      this.$router.push({ name: 'page.record.create', params: this.newRouteParams })
+      if (this.showRecordModal) {
+        this.inEditing = true
+        this.inCreating = true
+      } else {
+        this.$router.push({ name: 'page.record.create', params: this.newRouteParams })
+      }
     },
 
     handleClone () {
@@ -195,7 +237,12 @@ export default {
     },
 
     handleEdit () {
-      this.$router.push({ name: 'page.record.edit', params: this.$route.params })
+      if (this.showRecordModal) {
+        this.inEditing = true
+      } else {
+        this.$router.push({ name: 'page.record.edit', params: this.$route.params })
+      }
+      this.inEditing = true
     },
   },
 }

--- a/src/views/Public/Pages/Records/View.vue
+++ b/src/views/Public/Pages/Records/View.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="d-flex flex-grow-1 w-100 h-100">
+  <div
+    :class="{'flex-column': showRecordModal}"
+    class="d-flex flex-grow-1 w-100 h-100"
+  >
     <b-alert
       v-if="isDeleted"
       show
@@ -7,10 +10,6 @@
     >
       {{ $t('record.recordDeleted') }}
     </b-alert>
-
-    <portal to="topbar-title">
-      {{ title }}
-    </portal>
 
     <grid
       v-bind="$props"
@@ -21,34 +20,11 @@
     />
 
     <portal
-      v-if="showRecordModal"
-      to="record-modal-footer"
+      class="w-100"
+      :to="recordToolbar"
     >
       <record-toolbar
-        :module="module"
-        :record="record"
-        :labels="recordToolbarLabels"
-        :processing="processing"
-        :processing-submit="processingSubmit"
-        :processing-delete="processingDelete"
-        :is-deleted="isDeleted"
-        :in-editing="inEditing"
-        :hide-clone="inCreating"
-        :hide-add="inCreating"
-        @add="handleAdd()"
-        @clone="handleClone()"
-        @edit="handleEdit()"
-        @delete="handleDelete()"
-        @back="handleBack()"
-        @submit="handleFormSubmit('page.record')"
-      />
-    </portal>
-
-    <portal
-      v-else
-      to="toolbar"
-    >
-      <record-toolbar
+        :show-record-modal="showRecordModal"
         :module="module"
         :record="record"
         :labels="recordToolbarLabels"
@@ -129,6 +105,10 @@ export default {
   },
 
   computed: {
+    recordToolbar () {
+      return this.showRecordModal ? 'record-modal-footer' : 'toolbar'
+    },
+
     newRouteParams () {
       // Remove recordID and values from route params
       const { recordID, values, ...params } = this.$route.params
@@ -218,6 +198,7 @@ export default {
       if (this.showRecordModal) {
         this.inEditing = false
         this.inCreating = false
+        this.$bvModal.hide('record-modal')
       } else {
         this.$router.back()
       }
@@ -227,18 +208,25 @@ export default {
       if (this.showRecordModal) {
         this.inEditing = true
         this.inCreating = true
+        this.record = new compose.Record(this.module, { values: this.values })
       } else {
         this.$router.push({ name: 'page.record.create', params: this.newRouteParams })
       }
     },
 
     handleClone () {
-      this.$router.push({ name: 'page.record.create', params: { pageID: this.page.pageID, values: this.record.values } })
+      if (this.showRecordModal) {
+        this.inEditing = true
+        this.inCreating = true
+        this.record = new compose.Record(this.module, { values: this.record.values })
+      } else {
+        this.$router.push({ name: 'page.record.create', params: { pageID: this.page.pageID, values: this.record.values } })
+      }
     },
 
     handleEdit () {
       if (this.showRecordModal) {
-        this.inEditing = true
+        this.inCreating = false
       } else {
         this.$router.push({ name: 'page.record.edit', params: this.$route.params })
       }

--- a/src/views/Public/Pages/View.vue
+++ b/src/views/Public/Pages/View.vue
@@ -62,6 +62,10 @@
       />
     </div>
 
+    <record-modal
+      :namespace="namespace"
+    />
+
     <attachment-modal />
   </div>
 </template>
@@ -69,6 +73,7 @@
 import { mapActions } from 'vuex'
 import Grid from 'corteza-webapp-compose/src/components/Public/Page/Grid'
 import AttachmentModal from 'corteza-webapp-compose/src/components/Public/Page/Attachment/Modal'
+import RecordModal from 'corteza-webapp-compose/src/components/Public/Record/Modal'
 import PageTranslator from 'corteza-webapp-compose/src/components/Admin/Page/PageTranslator'
 import { compose, NoID } from '@cortezaproject/corteza-js'
 
@@ -80,6 +85,7 @@ export default {
   components: {
     Grid,
     AttachmentModal,
+    RecordModal,
     PageTranslator,
   },
 


### PR DESCRIPTION
## Screenshots of the Implementation

![image](https://user-images.githubusercontent.com/26258032/201335021-5e19e157-d630-4e6e-ad50-59663801833c.png)
Image 1 - Additional setting "Record Display Options" (select dropdown) in the record list page block

![image](https://user-images.githubusercontent.com/26258032/201334469-173deb17-9679-4e3f-8664-072a01e7e6c1.png)

Image 2 - Displaying a record entry as a modal

## Changelog

### What was added?

When adding a "record list" page block in the Compose page builder, a dropdown field has been added with three options:
- open record in the same tab
- open record in a new tab
- open record in a modal

The default option is to open in the same tab. 

_Note: The first two options already existed and are handled gracefully, e.g. respected for existing record lists_ 

The new thing here is the third option - "open record in a modal". When this option is selected and the user goes to a record list page or a page that displays record lists, he can click on a specific record and it will open as a modal. From the modal, the user can do whatever he wants with the existing record (edit, delete, clone) or even add a new record.

### How it was added?

In the Compose app, a root event was emitted from the RecordList component that emits an event with all the necessary information to a new modal component, which has been called from the public page. The modal is then able to display the record and its information. In order to do this, instead of using routes, the ViewRecord component is added as a child component to the modal and it receives its props from the modal itself.